### PR TITLE
Add alias for @textkernel/oneui in Storybook webpack config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,8 @@
             2,
             {
                 "ignore": [
-                    "bem"
+                    "bem",
+                    "@textkernel/oneui"
                 ]
             }
         ],

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,6 +1,10 @@
+const path = require('path');
 const { getRules, plugins, PACKAGES_PATH } = require('../etc/webpack/webpack.config');
 
 module.exports = (storybookBaseConfig, configType) => {
+
+    // Resolve OneUI package
+    storybookBaseConfig.resolve.alias['@textkernel/oneui'] = path.resolve(__dirname, '../src');
 
     // Add support to SASS
     storybookBaseConfig.module.rules.push(getRules('dev').styles);

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 export { default as Alert } from './components/Alert';
 export { default as Button } from './components/Button';
 export { default as ButtonGroup } from './components/ButtonGroup';
+export { default as CandidateAvatar } from './components/CandidateAvatar';
 export { default as Checkbox } from './components/Checkbox';
 export { default as Heading } from './components/Heading';
+export { default as Input } from './components/Input';
 export { default as Link } from './components/Link';
 export { default as LoadingSpinner } from './components/LoadingSpinner';
 export { default as ProgressBar } from './components/ProgressBar';

--- a/stories/Alert.js
+++ b/stories/Alert.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import Alert from '../src/components/Alert';
-import { CONTEXTS } from '../src/constants';
+import { Alert } from '@textkernel/oneui';
+import { CONTEXTS } from '@textkernel/oneui/constants';
 
 storiesOf('Alert', module)
     .addDecorator(withKnobs)

--- a/stories/Button.js
+++ b/stories/Button.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import Button from '../src/components/Button';
+import { Button } from '@textkernel/oneui';
 import { CONTEXTS, SIZES } from '../src/constants';
 
 storiesOf('Button', module)

--- a/stories/ButtonGroup.js
+++ b/stories/ButtonGroup.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, select, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import ButtonGroup from '../src/components/ButtonGroup';
-import Button from '../src/components/Button';
-import { SIZES } from '../src/constants';
+import { Button, ButtonGroup } from '@textkernel/oneui';
+import { SIZES } from '@textkernel/oneui/constants';
 
 storiesOf('ButtonGroup', module)
     .addDecorator(withKnobs)

--- a/stories/CandidateAvatar.js
+++ b/stories/CandidateAvatar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, number, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import CandidateAvatar from '../src/components/CandidateAvatar';
+import { CandidateAvatar } from '@textkernel/oneui';
 
 storiesOf('CandidateAvatar', module)
     .addDecorator(withKnobs)

--- a/stories/Checkbox.js
+++ b/stories/Checkbox.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import Checkbox from '../src/components/Checkbox';
+import { Checkbox } from '@textkernel/oneui';
 
 storiesOf('Checkbox', module)
     .addDecorator(withKnobs)

--- a/stories/Heading.js
+++ b/stories/Heading.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import Heading from '../src/components/Heading';
-import { HEADING_SIZES } from '../src/constants';
+import { Heading } from '@textkernel/oneui';
+import { HEADING_SIZES } from '@textkernel/oneui/constants';
 
 storiesOf('Heading', module)
     .addDecorator(withKnobs)

--- a/stories/Input.js
+++ b/stories/Input.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import Input from '../src/components/Input';
-import { CONTEXTS, INPUT_TYPES, SIZES } from '../src/constants';
+import { Input } from '@textkernel/oneui';
+import { CONTEXTS, INPUT_TYPES, SIZES } from '@textkernel/oneui/constants';
 
 storiesOf('Input', module)
     .addDecorator(withKnobs)

--- a/stories/Link.js
+++ b/stories/Link.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import Link from '../src/components/Link';
+import { Link } from '@textkernel/oneui';
 
 storiesOf('Link', module)
     .addDecorator(withKnobs)

--- a/stories/LoadingSpinner.js
+++ b/stories/LoadingSpinner.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, number, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import LoadingSpinner from '../src/components/LoadingSpinner';
-import { CONTEXTS } from '../src/constants';
+import { LoadingSpinner } from '@textkernel/oneui';
+import { CONTEXTS } from '@textkernel/oneui/constants';
 
 storiesOf('LoadingSpinner', module)
     .addDecorator(withKnobs)

--- a/stories/ProgressBar.js
+++ b/stories/ProgressBar.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, number, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import ProgressBar from '../src/components/ProgressBar';
-import { CONTEXTS } from '../src/constants';
+import { ProgressBar } from '@textkernel/oneui';
+import { CONTEXTS } from '@textkernel/oneui/constants';
 
 storiesOf('ProgressBar', module)
     .addDecorator(withKnobs)

--- a/stories/RadioButton.js
+++ b/stories/RadioButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import RadioButton from '../src/components/RadioButton';
+import { RadioButton } from '@textkernel/oneui';
 
 storiesOf('RadioButton', module)
     .addDecorator(withKnobs)

--- a/stories/Tabs.js
+++ b/stories/Tabs.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, select, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import Tab from '../src/components/Tabs/Tab';
-import TabContent from '../src/components/Tabs/TabContent';
-import TabItem from '../src/components/Tabs/TabItem';
-import TabMenu from '../src/components/Tabs/TabMenu';
-import Tabs from '../src/components/Tabs';
+import { Tab, Tabs, TabContent, TabItem, TabMenu } from '@textkernel/oneui';
 
 const tabs = [
     {

--- a/stories/Text.js
+++ b/stories/Text.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import Text from '../src/components/Text';
+import { Text } from '@textkernel/oneui';
 
 storiesOf('Text', module)
     .addDecorator(withKnobs)

--- a/stories/TextArea.js
+++ b/stories/TextArea.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
-import TextArea from '../src/components/TextArea';
-import { CONTEXTS, SIZES } from '../src/constants';
+import { TextArea } from '@textkernel/oneui';
+import { CONTEXTS, SIZES } from '@textkernel/oneui/constants';
 
 storiesOf('TextArea', module)
     .addDecorator(withKnobs)


### PR DESCRIPTION
Added alias for `@textkernel/oneui` in Storybook webpack config, so we can use it as a module in our stories. This is also useful to ensure that components are properly exported (already fixed two of them).