### PR TITLE
Make CandidateAvatar percentage scale to fit

### DIFF
--- a/src/components/CandidateAvatar/CandidateAvatar.js
+++ b/src/components/CandidateAvatar/CandidateAvatar.js
@@ -49,7 +49,17 @@ const CandidateAvatar = props => {
             >
                 {!!Number.isInteger(matchPercentage) &&
                     !!showPercentageOnHover && (
-                        <div {...elem('percentage', props)}>{`${percentage}%`}</div>
+                        <svg {...elem('percentage', props)} viewBox="0 0 50 50">
+                            <text
+                                {...elem('percentage-value', props)}
+                                x="50%"
+                                y="50%"
+                                textAnchor="middle"
+                                dominantBaseline="central"
+                            >
+                                {`${percentage}%`}
+                            </text>
+                        </svg>
                     )}
             </div>
             <svg

--- a/src/components/CandidateAvatar/CandidateAvatar.scss
+++ b/src/components/CandidateAvatar/CandidateAvatar.scss
@@ -30,22 +30,22 @@
     &__percentage {
         background-color: rgba(0,0,0,.25);
         border-radius: 50%;
-        color: white;
-        display: flex;
-        align-items: center;
-        justify-content: center;
         height: 100%;
         width: 100%;
         opacity: 0;
         user-select: none;
-        font: {
-            family: var(--font-family-primary);
-            size: var(--font-size-large);
-        }
-        text-shadow: 1px 1px 0 black;
-        text-overflow: ellipsis;
         transition: all var(--transition-duration);
         white-space: nowrap;
+
+        &-value {
+            fill: white;
+            font: {
+                family: var(--font-family-primary);
+                size: var(--font-size-large);
+            }
+            text-shadow: 1px 1px 0 black;
+            text-overflow: ellipsis;
+        }
     }
 
     &__image {

--- a/src/components/CandidateAvatar/__tests__/CandidateAvatar.spec.js
+++ b/src/components/CandidateAvatar/__tests__/CandidateAvatar.spec.js
@@ -28,8 +28,15 @@ describe('<CandidateAvatar> that renders a candidate profile image with match in
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('should render an avatar with bad match percentage', () => {
-        const wrapper = shallow(<CandidateAvatar size={128} matchPercentage={33} />);
+    it('should render an avatar with bad match percentage and avatar', () => {
+        const wrapper = shallow(
+            <CandidateAvatar
+                imageUrl="/candidate.jpg"
+                size={128}
+                matchPercentage={33}
+                showPercentageOnHover
+            />
+        );
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 

--- a/src/components/CandidateAvatar/__tests__/__snapshots__/CandidateAvatar.spec.js.snap
+++ b/src/components/CandidateAvatar/__tests__/__snapshots__/CandidateAvatar.spec.js.snap
@@ -73,7 +73,7 @@ exports[`<CandidateAvatar> that renders a candidate profile image with match ind
 </div>
 `;
 
-exports[`<CandidateAvatar> that renders a candidate profile image with match indication should render an avatar with bad match percentage 1`] = `
+exports[`<CandidateAvatar> that renders a candidate profile image with match indication should render an avatar with bad match percentage and avatar 1`] = `
 <div
   className="CandidateAvatar"
   style={
@@ -87,10 +87,25 @@ exports[`<CandidateAvatar> that renders a candidate profile image with match ind
     className="CandidateAvatar__image"
     style={
       Object {
-        "backgroundImage": "url(null)",
+        "backgroundImage": "url(/candidate.jpg)",
       }
     }
-  />
+  >
+    <svg
+      className="CandidateAvatar__percentage"
+      viewBox="0 0 50 50"
+    >
+      <text
+        className="CandidateAvatar__percentage-value"
+        dominantBaseline="central"
+        textAnchor="middle"
+        x="50%"
+        y="50%"
+      >
+        33%
+      </text>
+    </svg>
+  </div>
   <svg
     className="CandidateAvatar__ring"
     style={


### PR DESCRIPTION
* Switched to use SVG text to make percentage scale to fit parent container, no matter what size.