### PR TITLE
Enhance bem package

### DIFF
--- a/src/components/Alert/__tests__/__snapshots__/Alert.spec.js.snap
+++ b/src/components/Alert/__tests__/__snapshots__/Alert.spec.js.snap
@@ -2,13 +2,13 @@
 
 exports[`<Alert> that renders an alert should add classes when props are changed 1`] = `
 <div
-  className="Alert Alert--context_bad"
+  className="Alert Alert--context Alert--context_bad"
 >
   <div
-    className="Alert__content Alert__content--context_bad"
+    className="Alert__content Alert__content--context Alert__content--context_bad"
   >
     <strong
-      className="Alert__title Alert__title--context_bad"
+      className="Alert__title Alert__title--context Alert__title--context_bad"
     >
       Hey there
     </strong>
@@ -29,20 +29,20 @@ exports[`<Alert> that renders an alert should have a button that works 1`] = `
   title="Hey there"
 >
   <div
-    className="Alert Alert--context_brand"
+    className="Alert Alert--context Alert--context_brand"
   >
     <div
-      className="Alert__content Alert__content--context_brand"
+      className="Alert__content Alert__content--context Alert__content--context_brand"
     >
       <strong
-        className="Alert__title Alert__title--context_brand"
+        className="Alert__title Alert__title--context Alert__title--context_brand"
       >
         Hey there
       </strong>
       This is an alert with custom context and a title
     </div>
     <div
-      className="Alert__action Alert__action--context_brand"
+      className="Alert__action Alert__action--context Alert__action--context_brand"
     >
       <Button
         context="link"
@@ -53,7 +53,7 @@ exports[`<Alert> that renders an alert should have a button that works 1`] = `
         type="button"
       >
         <button
-          className="Button Button--context_link Button--size_normal"
+          className="Button Button--context Button--context_link Button--size Button--size_normal"
           context="link"
           disabled={false}
           onClick={[MockFunction]}
@@ -70,10 +70,10 @@ exports[`<Alert> that renders an alert should have a button that works 1`] = `
 
 exports[`<Alert> that renders an alert should render default alert correctly 1`] = `
 <div
-  className="Alert Alert--context_brand"
+  className="Alert Alert--context Alert--context_brand"
 >
   <div
-    className="Alert__content Alert__content--context_brand"
+    className="Alert__content Alert__content--context Alert__content--context_brand"
   >
     This is a basic alert without title or action
   </div>

--- a/src/components/Button/__tests__/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.spec.js.snap
@@ -9,7 +9,7 @@ exports[`<Button> that renders a button should add classes when props are change
   type="button"
 >
   <button
-    className="Button Button--context_primary Button--size_large Button--isBlock"
+    className="Button Button--context Button--context_primary Button--size Button--size_large Button--isBlock"
     context="primary"
     disabled={false}
     size="large"
@@ -31,7 +31,7 @@ exports[`<Button> that renders a button should render default button correctly 1
   type="button"
 >
   <button
-    className="Button Button--context_neutral Button--size_normal"
+    className="Button Button--context Button--context_neutral Button--size Button--size_normal"
     context="neutral"
     disabled={false}
     size="normal"

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -6,10 +6,10 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
   size="large"
 >
   <div
-    className="ButtonGroup ButtonGroup--size_large ButtonGroup--isBlock"
+    className="ButtonGroup ButtonGroup--size ButtonGroup--size_large ButtonGroup--isBlock"
   >
     <Button
-      className="ButtonGroup__button ButtonGroup__button--size_large ButtonGroup__button--isBlock"
+      className="ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_large ButtonGroup__button--isBlock"
       context="neutral"
       disabled={false}
       isBlock={false}
@@ -18,7 +18,7 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
       type="button"
     >
       <button
-        className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--size_large ButtonGroup__button--isBlock"
+        className="Button Button--context Button--context_neutral Button--size Button--size_large ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_large ButtonGroup__button--isBlock"
         context="neutral"
         disabled={false}
         size="large"
@@ -28,7 +28,7 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
       </button>
     </Button>
     <Button
-      className="ButtonGroup__button ButtonGroup__button--size_large ButtonGroup__button--isBlock"
+      className="ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_large ButtonGroup__button--isBlock"
       context="neutral"
       disabled={false}
       isBlock={false}
@@ -37,7 +37,7 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
       type="button"
     >
       <button
-        className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--size_large ButtonGroup__button--isBlock"
+        className="Button Button--context Button--context_neutral Button--size Button--size_large ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_large ButtonGroup__button--isBlock"
         context="neutral"
         disabled={false}
         size="large"
@@ -56,10 +56,10 @@ exports[`<ButtonGroup> that renders a button should render default button correc
   size="normal"
 >
   <div
-    className="ButtonGroup ButtonGroup--size_normal"
+    className="ButtonGroup ButtonGroup--size ButtonGroup--size_normal"
   >
     <Button
-      className="ButtonGroup__button ButtonGroup__button--size_normal"
+      className="ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_normal"
       context="neutral"
       disabled={false}
       isBlock={false}
@@ -68,7 +68,7 @@ exports[`<ButtonGroup> that renders a button should render default button correc
       type="button"
     >
       <button
-        className="Button Button--context_neutral Button--size_normal ButtonGroup__button ButtonGroup__button--size_normal"
+        className="Button Button--context Button--context_neutral Button--size Button--size_normal ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_normal"
         context="neutral"
         disabled={false}
         size="normal"
@@ -78,7 +78,7 @@ exports[`<ButtonGroup> that renders a button should render default button correc
       </button>
     </Button>
     <Button
-      className="ButtonGroup__button ButtonGroup__button--size_normal"
+      className="ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_normal"
       context="neutral"
       disabled={false}
       isBlock={false}
@@ -87,7 +87,7 @@ exports[`<ButtonGroup> that renders a button should render default button correc
       type="button"
     >
       <button
-        className="Button Button--context_neutral Button--size_normal ButtonGroup__button ButtonGroup__button--size_normal"
+        className="Button Button--context Button--context_neutral Button--size Button--size_normal ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_normal"
         context="neutral"
         disabled={false}
         size="normal"

--- a/src/components/CandidateAvatar/__tests__/__snapshots__/CandidateAvatar.spec.js.snap
+++ b/src/components/CandidateAvatar/__tests__/__snapshots__/CandidateAvatar.spec.js.snap
@@ -58,7 +58,7 @@ exports[`<CandidateAvatar> that renders a candidate profile image with match ind
     }
   >
     <circle
-      className="CandidateAvatar__circle CandidateAvatar__circle--context_warning"
+      className="CandidateAvatar__circle CandidateAvatar__circle--context CandidateAvatar__circle--context_warning"
       cx={64}
       cy={64}
       r={62}
@@ -101,7 +101,7 @@ exports[`<CandidateAvatar> that renders a candidate profile image with match ind
     }
   >
     <circle
-      className="CandidateAvatar__circle CandidateAvatar__circle--context_bad"
+      className="CandidateAvatar__circle CandidateAvatar__circle--context CandidateAvatar__circle--context_bad"
       cx={64}
       cy={64}
       r={62}

--- a/src/components/Heading/__tests__/__snapshots__/Heading.spec.js.snap
+++ b/src/components/Heading/__tests__/__snapshots__/Heading.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Heading> that renders a heading should add classes when props are changed 1`] = `
 <h3
-  className="Heading Heading--align_right Heading--level_h3"
+  className="Heading Heading--align Heading--align_right Heading--level Heading--level_h3"
 >
   Some heading text
 </h3>
@@ -10,7 +10,7 @@ exports[`<Heading> that renders a heading should add classes when props are chan
 
 exports[`<Heading> that renders a heading should render default heading correctly 1`] = `
 <h1
-  className="Heading Heading--align_left Heading--level_h1"
+  className="Heading Heading--align Heading--align_left Heading--level Heading--level_h1"
 >
   Some heading text
 </h1>

--- a/src/components/Input/__tests__/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<Input> that renders an input field should add classes when props are changed 1`] = `
 <input
-  className="Input Input--context_bad Input--isBlock Input--size_large"
+  className="Input Input--context Input--context_bad Input--isBlock Input--size Input--size_large"
   disabled={true}
   type="text"
 />
@@ -10,7 +10,7 @@ exports[`<Input> that renders an input field should add classes when props are c
 
 exports[`<Input> that renders an input field should render default input correctly 1`] = `
 <input
-  className="Input Input--context_brand Input--size_normal"
+  className="Input Input--context Input--context_brand Input--size Input--size_normal"
   disabled={false}
   type="text"
   value="Some value"

--- a/src/components/LoadingSpinner/__tests__/__snapshots__/LoadingSpinner.spec.js.snap
+++ b/src/components/LoadingSpinner/__tests__/__snapshots__/LoadingSpinner.spec.js.snap
@@ -2,10 +2,10 @@
 
 exports[`<LoadingSpinner> that renders a circular loading spinner should add classes when props are changed 1`] = `
 <div
-  className="LoadingSpinner LoadingSpinner--centerIn_viewport LoadingSpinner--context_primary LoadingSpinner--hidden"
+  className="LoadingSpinner LoadingSpinner--centerIn LoadingSpinner--centerIn_viewport LoadingSpinner--context LoadingSpinner--context_primary LoadingSpinner--hidden"
 >
   <svg
-    className="LoadingSpinner__svg LoadingSpinner__svg--centerIn_viewport LoadingSpinner__svg--context_primary LoadingSpinner__svg--hidden"
+    className="LoadingSpinner__svg LoadingSpinner__svg--centerIn LoadingSpinner__svg--centerIn_viewport LoadingSpinner__svg--context LoadingSpinner__svg--context_primary LoadingSpinner__svg--hidden"
     style={
       Object {
         "height": 12,
@@ -22,7 +22,7 @@ exports[`<LoadingSpinner> that renders a circular loading spinner should add cla
     }
   >
     <circle
-      className="LoadingSpinner__path LoadingSpinner__path--centerIn_viewport LoadingSpinner__path--context_primary LoadingSpinner__path--hidden"
+      className="LoadingSpinner__path LoadingSpinner__path--centerIn LoadingSpinner__path--centerIn_viewport LoadingSpinner__path--context LoadingSpinner__path--context_primary LoadingSpinner__path--hidden"
       cx="22"
       cy="22"
       fill="none"
@@ -35,10 +35,10 @@ exports[`<LoadingSpinner> that renders a circular loading spinner should add cla
 
 exports[`<LoadingSpinner> that renders a circular loading spinner should render a default spinner correctly 1`] = `
 <div
-  className="LoadingSpinner LoadingSpinner--context_brand"
+  className="LoadingSpinner LoadingSpinner--context LoadingSpinner--context_brand"
 >
   <svg
-    className="LoadingSpinner__svg LoadingSpinner__svg--context_brand"
+    className="LoadingSpinner__svg LoadingSpinner__svg--context LoadingSpinner__svg--context_brand"
     style={null}
     viewBox={
       Array [
@@ -50,7 +50,7 @@ exports[`<LoadingSpinner> that renders a circular loading spinner should render 
     }
   >
     <circle
-      className="LoadingSpinner__path LoadingSpinner__path--context_brand"
+      className="LoadingSpinner__path LoadingSpinner__path--context LoadingSpinner__path--context_brand"
       cx="22"
       cy="22"
       fill="none"
@@ -63,10 +63,10 @@ exports[`<LoadingSpinner> that renders a circular loading spinner should render 
 
 exports[`<LoadingSpinner> that renders a circular loading spinner should render a spinner with label 1`] = `
 <div
-  className="LoadingSpinner LoadingSpinner--context_brand"
+  className="LoadingSpinner LoadingSpinner--context LoadingSpinner--context_brand"
 >
   <svg
-    className="LoadingSpinner__svg LoadingSpinner__svg--context_brand"
+    className="LoadingSpinner__svg LoadingSpinner__svg--context LoadingSpinner__svg--context_brand"
     style={null}
     viewBox={
       Array [
@@ -78,7 +78,7 @@ exports[`<LoadingSpinner> that renders a circular loading spinner should render 
     }
   >
     <circle
-      className="LoadingSpinner__path LoadingSpinner__path--context_brand"
+      className="LoadingSpinner__path LoadingSpinner__path--context LoadingSpinner__path--context_brand"
       cx="22"
       cy="22"
       fill="none"
@@ -87,7 +87,7 @@ exports[`<LoadingSpinner> that renders a circular loading spinner should render 
     />
   </svg>
   <Text
-    className="LoadingSpinner__label LoadingSpinner__label--context_brand"
+    className="LoadingSpinner__label LoadingSpinner__label--context LoadingSpinner__label--context_brand"
     inline={true}
     muted={false}
   >

--- a/src/components/ProgressBar/__tests__/__snapshots__/ProgressBar.spec.js.snap
+++ b/src/components/ProgressBar/__tests__/__snapshots__/ProgressBar.spec.js.snap
@@ -2,10 +2,10 @@
 
 exports[`<ProgressBar> that renders a horizontal progress bar should render a default progress bar correctly 1`] = `
 <div
-  className="ProgressBar ProgressBar--context_brand"
+  className="ProgressBar ProgressBar--context ProgressBar--context_brand"
 >
   <div
-    className="ProgressBar__fill ProgressBar__fill--context_brand"
+    className="ProgressBar__fill ProgressBar__fill--context ProgressBar__fill--context_brand"
     style={
       Object {
         "width": "25%",

--- a/src/components/TextArea/__tests__/__snapshots__/TextArea.spec.js.snap
+++ b/src/components/TextArea/__tests__/__snapshots__/TextArea.spec.js.snap
@@ -2,14 +2,14 @@
 
 exports[`<TextArea> that renders a textarea should add classes when props are changed 1`] = `
 <textarea
-  className="TextArea TextArea--context_bad TextArea--isBlock TextArea--size_large"
+  className="TextArea TextArea--context TextArea--context_bad TextArea--isBlock TextArea--size TextArea--size_large"
   disabled={true}
 />
 `;
 
 exports[`<TextArea> that renders a textarea should render default textarea correctly 1`] = `
 <textarea
-  className="TextArea TextArea--context_brand TextArea--size_normal"
+  className="TextArea TextArea--context TextArea--context_brand TextArea--size TextArea--size_normal"
   defaultValue="Some value"
   disabled={false}
 />

--- a/src/packages/bem/README.md
+++ b/src/packages/bem/README.md
@@ -54,8 +54,8 @@ class Button extends Component {
 
     render() {
         return (
-            {/*  
-            3. Add { ...this.block() } construction to declare node as a block root 
+            {/*
+            3. Add { ...this.block() } construction to declare node as a block root
                Note! If needed, {...this.props} should be spreaded before { ...this.block() } in order
                to avoid className overwriting.
             */}
@@ -104,7 +104,7 @@ import classnamesMap from './Button.scss';
 
 const { block, elem } = bem({
     name: 'Button', // Block name, that is used in css classnames
-    classnames: classnamesMap, 
+    classnames: classnamesMap,
     // 1. If you need to have class name (.ButtonStateless--active) that depends on
     //    `active` prop, just list this prop in propsToMods list.
     propsToMods: ['active']
@@ -144,7 +144,7 @@ Button.scss
 
     display: inline-block;
 
-    /* 
+    /*
     Block: "Button", modifier: "active" (based on props.active), value: true.
     Is applied to the component's root node when props.active = true is set.
     */
@@ -152,7 +152,15 @@ Button.scss
         color: red;
     }
 
-    /* 
+    /*
+    Block: "Button", modifier: "type" (based on props.type), any truthy value.
+    Is applied to the component's root node when `props.type = "normal"` is set.
+    */
+    &--type {
+        border: 1px;
+    }
+
+    /*
     Block: "Button", modifier: "type" (based on props.type), value: "normal".
     Is applied to the component's root node when `props.type = "normal"` is set.
     */
@@ -160,7 +168,7 @@ Button.scss
         background-color: grey;
     }
 
-    /* 
+    /*
     Block "Button", modifier "type" (based on props.type), value "extraordinary".
     Is applied to the component's root node when `props.type = "extraordinary"` is set.
     */
@@ -168,7 +176,7 @@ Button.scss
         background-color: red;
     }
 
-    /* 
+    /*
     Block "Button", modifier "clicked" (based on state.clicked), value true.
     Is applied to the component's root node when `state.clicked = true` is set.
     */
@@ -176,7 +184,7 @@ Button.scss
         border-style: dashed;
     }
 
-    /* 
+    /*
     Block "Button", element "label"
     Is applied to the component's label node.
     */
@@ -184,7 +192,7 @@ Button.scss
         color: blue;
     }
 
-    /* 
+    /*
     Block "Button", element "label", modifier: "active" (based on props.active), value: true.
     Is applied to the component's label node when props.active = true is set.
     */
@@ -193,7 +201,7 @@ Button.scss
     }
 
 
-/* 
+/*
     Block "Button", element "label", modifier "extraordinary" (based on props.type), value "extraordinary".
     Is applied to the component's label node when `props.type = "extraordinary"` is set.
     */
@@ -233,15 +241,15 @@ respectively exists in classnames map.
 
 ### Prop `active` and `type` are set:
 
-**Note** that property of a boolean type `active={true}` produces `Button__label--active` (*without* mod value), when property of a string type `type='extraordinary'` gives us classname `Button__label--type_extraordinary` (*with* mod value)
+**Note** that property of a boolean type `active={true}` produces `Button__label--active` (*without* mod value), when property of a string type `type='extraordinary'` gives us two classnameas: `Button__label--type` (*without* mod value) and `Button__label--type_extraordinary` (*with* mod value).
 
 ```html
 <Button active={true} type='extraordinary' />
 
     ↓ ↓ ↓
 
-<button class="Button Button--active Button--type_extraordinary">
-    <span class="Button__label Button__label--active Button__label--type_extraordinary" />
+<button class="Button Button--active Button--type Button--type_extraordinary">
+    <span class="Button__label Button__label--active Button__label--type Button__label--type_extraordinary" />
 </button>
 ```
 
@@ -261,7 +269,7 @@ No classnames will be produced if boolean property has `false` value.
 ### Clicked state
 ```html
 <Button /> <!-- this.setState({ clicked: true }) -->
- 
+
     ↓ ↓ ↓
 
 <button class="Button Button--clicked">

--- a/src/packages/bem/__tests__/bem.spec.js
+++ b/src/packages/bem/__tests__/bem.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, ButtonStateless } from './dummy-components';
+import { Button, ButtonStateless, Avatar, AvatarStateless } from './dummy-components';
 
 describe('BEM decorator', () => {
     describe('Decorate stateFUL class component', () => {
@@ -35,6 +35,27 @@ describe('BEM decorator', () => {
             expect(buttonLabel.hasClass('Button__label--active')).toBe(true);
             expect(buttonLabel.hasClass('Button__label--context_error')).toBe(true);
             expect(buttonLabel.hasClass('Button__label--size_2')).toBe(true);
+        });
+
+        it('should add proper class names based on extra mods with string value', () => {
+            const avatarWrapper = shallow(<Avatar match={80} />);
+            const avatarImage = avatarWrapper.childAt(0);
+            expect(avatarWrapper.hasClass('Avatar--outlineColor_green')).toBe(true);
+            expect(avatarImage.hasClass('Avatar__image--outlineColor_green')).toBe(true);
+        });
+
+        it('should add proper class names based on extra mods with number value', () => {
+            const avatarWrapper = shallow(<Avatar match={58} />);
+            const avatarImage = avatarWrapper.childAt(0);
+            expect(avatarWrapper.hasClass('Avatar--unmatchScore_42')).toBe(true);
+            expect(avatarImage.hasClass('Avatar__image--unmatchScore_42')).toBe(true);
+        });
+
+        it('should add proper class names based on extra mods with boolean value', () => {
+            const avatarWrapper = shallow(<Avatar match={100} />);
+            const avatarImage = avatarWrapper.childAt(0);
+            expect(avatarWrapper.hasClass('Avatar--isPerfect')).toBe(true);
+            expect(avatarImage.hasClass('Avatar__image--isPerfect')).toBe(true);
         });
 
         it('should not add a class names if they are not listed in classnamesMap', () => {
@@ -94,6 +115,27 @@ describe('BEM decorator', () => {
             expect(buttonLabel.hasClass('ButtonStateless__label--active')).toBe(true);
             expect(buttonLabel.hasClass('ButtonStateless__label--context_error')).toBe(true);
             expect(buttonLabel.hasClass('ButtonStateless__label--size_2')).toBe(true);
+        });
+
+        it('should add proper class names based on extra mods with string value', () => {
+            const avatarWrapper = shallow(<AvatarStateless match={80} />);
+            const avatarImage = avatarWrapper.childAt(0);
+            expect(avatarWrapper.hasClass('AvatarStateless--outlineColor_green')).toBe(true);
+            expect(avatarImage.hasClass('AvatarStateless__image--outlineColor_green')).toBe(true);
+        });
+
+        it('should add proper class names based on extra mods with number value', () => {
+            const avatarWrapper = shallow(<AvatarStateless match={58} />);
+            const avatarImage = avatarWrapper.childAt(0);
+            expect(avatarWrapper.hasClass('AvatarStateless--unmatchScore_42')).toBe(true);
+            expect(avatarImage.hasClass('AvatarStateless__image--unmatchScore_42')).toBe(true);
+        });
+
+        it('should add proper class names based on extra mods with boolean value', () => {
+            const avatarWrapper = shallow(<AvatarStateless match={100} />);
+            const avatarImage = avatarWrapper.childAt(0);
+            expect(avatarWrapper.hasClass('AvatarStateless--isPerfect')).toBe(true);
+            expect(avatarImage.hasClass('AvatarStateless__image--isPerfect')).toBe(true);
         });
 
         it('should not add a class names if they are not listed in classnames map', () => {

--- a/src/packages/bem/__tests__/bem.spec.js
+++ b/src/packages/bem/__tests__/bem.spec.js
@@ -37,6 +37,16 @@ describe('BEM decorator', () => {
             expect(buttonLabel.hasClass('Button__label--size_2')).toBe(true);
         });
 
+        it('should add "wildcard" class names for modifier with value (striong or number)', () => {
+            const buttonWrapper = shallow(<Button size={3} />);
+            const buttonIcon = buttonWrapper.childAt(0);
+            const buttonLabel = buttonWrapper.childAt(1);
+            expect(buttonWrapper.hasClass('Button--size')).toBe(true);
+            expect(buttonWrapper.hasClass('Button--context')).toBe(false);
+            expect(buttonIcon.hasClass('Button__icon--size')).toBe(true);
+            expect(buttonLabel.hasClass('Button__label--size')).toBe(false);
+        });
+
         it('should add proper class names based on extra mods with string value', () => {
             const avatarWrapper = shallow(<Avatar match={80} />);
             const avatarImage = avatarWrapper.childAt(0);
@@ -115,6 +125,16 @@ describe('BEM decorator', () => {
             expect(buttonLabel.hasClass('ButtonStateless__label--active')).toBe(true);
             expect(buttonLabel.hasClass('ButtonStateless__label--context_error')).toBe(true);
             expect(buttonLabel.hasClass('ButtonStateless__label--size_2')).toBe(true);
+        });
+
+        it('should add "wildcard" class names for modifier with value (striong or number)', () => {
+            const buttonWrapper = shallow(<ButtonStateless size={2} />);
+            const buttonIcon = buttonWrapper.childAt(0);
+            const buttonLabel = buttonWrapper.childAt(1);
+            expect(buttonWrapper.hasClass('ButtonStateless--context')).toBe(false);
+            expect(buttonWrapper.hasClass('ButtonStateless--size')).toBe(true);
+            expect(buttonIcon.hasClass('ButtonStateless__icon--size')).toBe(true);
+            expect(buttonLabel.hasClass('ButtonStateless__label--size')).toBe(false);
         });
 
         it('should add proper class names based on extra mods with string value', () => {

--- a/src/packages/bem/__tests__/bem.spec.js
+++ b/src/packages/bem/__tests__/bem.spec.js
@@ -23,15 +23,18 @@ describe('BEM decorator', () => {
         });
 
         it('should add proper class names based on propsToMods and passed props', () => {
-            const buttonWrapper = shallow(<Button active context="error" />);
+            const buttonWrapper = shallow(<Button active context="error" size={2} />);
             const buttonIcon = buttonWrapper.childAt(0);
             const buttonLabel = buttonWrapper.childAt(1);
             expect(buttonWrapper.hasClass('Button--active')).toBe(true);
             expect(buttonWrapper.hasClass('Button--context_error')).toBe(true);
+            expect(buttonWrapper.hasClass('Button--size_2')).toBe(true);
             expect(buttonIcon.hasClass('Button__icon--active')).toBe(true);
             expect(buttonIcon.hasClass('Button__icon--context_error')).toBe(true);
+            expect(buttonIcon.hasClass('Button__icon--size_2')).toBe(true);
             expect(buttonLabel.hasClass('Button__label--active')).toBe(true);
             expect(buttonLabel.hasClass('Button__label--context_error')).toBe(true);
+            expect(buttonLabel.hasClass('Button__label--size_2')).toBe(true);
         });
 
         it('should not add a class names if they are not listed in classnamesMap', () => {
@@ -79,15 +82,18 @@ describe('BEM decorator', () => {
         });
 
         it('should add proper class names based on propsToMods and passed props', () => {
-            const buttonWrapper = shallow(<ButtonStateless active context="error" />);
+            const buttonWrapper = shallow(<ButtonStateless active context="error" size={2} />);
             const buttonIcon = buttonWrapper.childAt(0);
             const buttonLabel = buttonWrapper.childAt(1);
             expect(buttonWrapper.hasClass('ButtonStateless--active')).toBe(true);
             expect(buttonWrapper.hasClass('ButtonStateless--context_error')).toBe(true);
+            expect(buttonWrapper.hasClass('ButtonStateless--size_2')).toBe(true);
             expect(buttonIcon.hasClass('ButtonStateless__icon--active')).toBe(true);
             expect(buttonIcon.hasClass('ButtonStateless__icon--context_error')).toBe(true);
+            expect(buttonIcon.hasClass('ButtonStateless__icon--size_2')).toBe(true);
             expect(buttonLabel.hasClass('ButtonStateless__label--active')).toBe(true);
             expect(buttonLabel.hasClass('ButtonStateless__label--context_error')).toBe(true);
+            expect(buttonLabel.hasClass('ButtonStateless__label--size_2')).toBe(true);
         });
 
         it('should not add a class names if they are not listed in classnames map', () => {

--- a/src/packages/bem/__tests__/dummy-components/Avatar/Avatar.jsx
+++ b/src/packages/bem/__tests__/dummy-components/Avatar/Avatar.jsx
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import bem from '../../../';
+import classnamesMap from './classnamesMap.json';
+
+class Avatar extends Component {
+
+    static displayName = 'Avatar';
+
+    static propTypes = {
+        match: PropTypes.number,
+    }
+
+    static defaultProps = {
+        match: 0,
+    }
+
+    calculateOutlineColor() {
+        const { match } = this.props;
+        if (match > 77) return 'green';
+        if (match > 33) return 'yellow';
+        if (match >= 0) return 'red';
+        return 'red';
+    }
+
+    calculateIsPerfect() {
+        const { match } = this.props;
+        return match === 100;
+    }
+
+    calculateUnmatchScore() {
+        const { match } = this.props;
+        return 100 - match;
+    }
+
+    render() {
+        const outlineColor = this.calculateOutlineColor();
+        const isPerfect = this.calculateIsPerfect();
+        const unmatchScore = this.calculateUnmatchScore();
+        const extraMods = {
+            outlineColor, // String mod
+            unmatchScore, // Number mod
+            isPerfect, // Boolean mod
+        };
+        return (
+            <div { ...this.block(extraMods) }>
+                <div { ...this.elem('image', extraMods) }>
+                    {this.props.children}
+                </div>
+            </div>
+        );
+    }
+}
+
+export default bem(classnamesMap)(Avatar);

--- a/src/packages/bem/__tests__/dummy-components/Avatar/classnamesMap.json
+++ b/src/packages/bem/__tests__/dummy-components/Avatar/classnamesMap.json
@@ -1,0 +1,11 @@
+{
+  "Avatar": "Avatar",
+  "Avatar--outlineColor_green": "Avatar--outlineColor_green",
+  "Avatar--unmatchScore_42": "Avatar--unmatchScore_42",
+  "Avatar--isPerfect": "Avatar--isPerfect",
+  
+  "Avatar__image": "Avatar__image",
+  "Avatar__image--outlineColor_green": "Avatar__image--outlineColor_green",
+  "Avatar__image--unmatchScore_42": "Avatar__image--unmatchScore_42",
+  "Avatar__image--isPerfect": "Avatar__image--isPerfect"
+}

--- a/src/packages/bem/__tests__/dummy-components/Avatar/index.js
+++ b/src/packages/bem/__tests__/dummy-components/Avatar/index.js
@@ -1,0 +1,1 @@
+export { default } from './Avatar';

--- a/src/packages/bem/__tests__/dummy-components/AvatarStateless/AvatarStateless.jsx
+++ b/src/packages/bem/__tests__/dummy-components/AvatarStateless/AvatarStateless.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import bem from '../../..';
+import classnamesMap from './classnamesMap.json';
+
+const { block, elem } = bem({
+    name: 'AvatarStateless',
+    classnames: classnamesMap,
+    propsToMods: [],
+});
+
+const calculateOutlineColor = (match) => {
+    if (match > 77) return 'green';
+    if (match > 33) return 'yellow';
+    if (match >= 0) return 'red';
+    return 'red';
+}
+
+const calculateIsPerfect = (match) => match === 100;
+
+const calculateUnmatchScore = (match) => 100 - match;
+
+const AvatarStateless = (props) => {
+
+    const { match, children } = props;
+    const outlineColor = calculateOutlineColor(match);
+    const isPerfect = calculateIsPerfect(match);
+    const unmatchScore = calculateUnmatchScore(match);
+    const extraMods = {
+        outlineColor, // String mod
+        unmatchScore, // Number mod
+        isPerfect, // Boolean mod
+    };
+
+    return (
+        <div {...block(props, extraMods)}>
+            <div {...elem('image', props, extraMods)}>
+                {children}
+            </div>
+        </div>
+    );
+    
+};
+
+AvatarStateless.displayName = 'AvatarStateless';
+
+AvatarStateless.propTypes = {
+    match: PropTypes.number,
+}
+
+AvatarStateless.defaultProps = {
+    match: 0,
+}
+
+export default AvatarStateless;

--- a/src/packages/bem/__tests__/dummy-components/AvatarStateless/classnamesMap.json
+++ b/src/packages/bem/__tests__/dummy-components/AvatarStateless/classnamesMap.json
@@ -1,0 +1,11 @@
+{
+  "AvatarStateless": "AvatarStateless",
+  "AvatarStateless--outlineColor_green": "AvatarStateless--outlineColor_green",
+  "AvatarStateless--unmatchScore_42": "AvatarStateless--unmatchScore_42",
+  "AvatarStateless--isPerfect": "AvatarStateless--isPerfect",
+  
+  "AvatarStateless__image": "AvatarStateless__image",
+  "AvatarStateless__image--outlineColor_green": "AvatarStateless__image--outlineColor_green",
+  "AvatarStateless__image--unmatchScore_42": "AvatarStateless__image--unmatchScore_42",
+  "AvatarStateless__image--isPerfect": "AvatarStateless__image--isPerfect"
+}

--- a/src/packages/bem/__tests__/dummy-components/AvatarStateless/index.js
+++ b/src/packages/bem/__tests__/dummy-components/AvatarStateless/index.js
@@ -1,0 +1,1 @@
+export { default } from './AvatarStateless';

--- a/src/packages/bem/__tests__/dummy-components/Button/Button.jsx
+++ b/src/packages/bem/__tests__/dummy-components/Button/Button.jsx
@@ -1,12 +1,29 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import bem from '../../../';
 import classnamesMap from './classnamesMap.json';
 
 class Button extends Component {
 
     static displayName = 'Button';
-    static propsToMods = ['active', 'disabled', 'context'];
+
+    static propsToMods = ['active', 'disabled', 'context', 'size'];
+
     static stateToMods = ['clicked'];
+
+    static propTypes = {
+        active: PropTypes.bool,
+        disabled: PropTypes.bool,
+        context: PropTypes.string,
+        size: PropTypes.oneOf([1, 2, 3]),
+    }
+
+    static defaultProps = {
+        active: false,
+        disabled: false,
+        context: 'default',
+        size: 1,
+    }
 
     state = { clicked: false };
 

--- a/src/packages/bem/__tests__/dummy-components/Button/classnamesMap.json
+++ b/src/packages/bem/__tests__/dummy-components/Button/classnamesMap.json
@@ -3,14 +3,17 @@
   "Button--clicked": "Button--clicked",
   "Button--active": "Button--active",
   "Button--context_error": "Button--context_error",
+  "Button--size_2": "Button--size_2",
   
   "Button__icon": "Button",
   "Button__icon--clicked": "Button__icon--clicked",
   "Button__icon--active": "Button__icon--active",
   "Button__icon--context_error": "Button__icon--context_error",
+  "Button__icon--size_2": "Button__icon--size_2",
   
   "Button__label": "Button__label",
   "Button__label--clicked": "Button__label--clicked",
   "Button__label--active": "Button__label--active",
-  "Button__label--context_error": "Button__label--context_error"
+  "Button__label--context_error": "Button__label--context_error",
+  "Button__label--size_2": "Button__label--size_2"
 }

--- a/src/packages/bem/__tests__/dummy-components/Button/classnamesMap.json
+++ b/src/packages/bem/__tests__/dummy-components/Button/classnamesMap.json
@@ -3,14 +3,16 @@
   "Button--clicked": "Button--clicked",
   "Button--active": "Button--active",
   "Button--context_error": "Button--context_error",
+  "Button--size": "Button--size",
   "Button--size_2": "Button--size_2",
-  
+
   "Button__icon": "Button",
   "Button__icon--clicked": "Button__icon--clicked",
   "Button__icon--active": "Button__icon--active",
   "Button__icon--context_error": "Button__icon--context_error",
+  "Button__icon--size": "Button__icon--size",
   "Button__icon--size_2": "Button__icon--size_2",
-  
+
   "Button__label": "Button__label",
   "Button__label--clicked": "Button__label--clicked",
   "Button__label--active": "Button__label--active",

--- a/src/packages/bem/__tests__/dummy-components/ButtonStateless/ButtonStateless.jsx
+++ b/src/packages/bem/__tests__/dummy-components/ButtonStateless/ButtonStateless.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import bem from '../../../';
 import classnamesMap from './classnamesMap.json';
 
 const { block, elem } = bem({
     name: 'ButtonStateless',
     classnames: classnamesMap,
-    propsToMods: ['active', 'disabled', 'context']
+    propsToMods: ['active', 'disabled', 'context', 'size']
 });
 
 const ButtonStateless = (props) => (
@@ -16,5 +17,21 @@ const ButtonStateless = (props) => (
         </span>
     </button>
 );
+
+ButtonStateless.displayName = 'ButtonStateless';
+
+ButtonStateless.propTypes = {
+    active: PropTypes.bool,
+    disabled: PropTypes.bool,
+    context: PropTypes.string,
+    size: PropTypes.oneOf([1, 2, 3]),
+};
+
+ButtonStateless.defaultProps = {
+    active: false,
+    disabled: false,
+    context: 'default',
+    size: 1,
+};
 
 export default ButtonStateless;

--- a/src/packages/bem/__tests__/dummy-components/ButtonStateless/classnamesMap.json
+++ b/src/packages/bem/__tests__/dummy-components/ButtonStateless/classnamesMap.json
@@ -3,14 +3,17 @@
   "ButtonStateless--clicked": "ButtonStateless--clicked",
   "ButtonStateless--active": "ButtonStateless--active",
   "ButtonStateless--context_error": "ButtonStateless--context_error",
+  "ButtonStateless--size_2": "ButtonStateless--size_2",
   
   "ButtonStateless__icon": "ButtonStateless",
   "ButtonStateless__icon--clicked": "ButtonStateless__icon--clicked",
   "ButtonStateless__icon--active": "ButtonStateless__icon--active",
   "ButtonStateless__icon--context_error": "ButtonStateless__icon--context_error",
+  "ButtonStateless__icon--size_2": "ButtonStateless__icon--size_2",
   
   "ButtonStateless__label": "ButtonStateless__label",
   "ButtonStateless__label--clicked": "ButtonStateless__label--clicked",
   "ButtonStateless__label--active": "ButtonStateless__label--active",
-  "ButtonStateless__label--context_error": "ButtonStateless__label--context_error"
+  "ButtonStateless__label--context_error": "ButtonStateless__label--context_error",
+  "ButtonStateless__label--size_2": "ButtonStateless__label--size_2"
 }

--- a/src/packages/bem/__tests__/dummy-components/ButtonStateless/classnamesMap.json
+++ b/src/packages/bem/__tests__/dummy-components/ButtonStateless/classnamesMap.json
@@ -3,14 +3,16 @@
   "ButtonStateless--clicked": "ButtonStateless--clicked",
   "ButtonStateless--active": "ButtonStateless--active",
   "ButtonStateless--context_error": "ButtonStateless--context_error",
+  "ButtonStateless--size": "ButtonStateless--size",
   "ButtonStateless--size_2": "ButtonStateless--size_2",
-  
+
   "ButtonStateless__icon": "ButtonStateless",
   "ButtonStateless__icon--clicked": "ButtonStateless__icon--clicked",
   "ButtonStateless__icon--active": "ButtonStateless__icon--active",
   "ButtonStateless__icon--context_error": "ButtonStateless__icon--context_error",
+  "ButtonStateless__icon--size": "ButtonStateless__icon--size",
   "ButtonStateless__icon--size_2": "ButtonStateless__icon--size_2",
-  
+
   "ButtonStateless__label": "ButtonStateless__label",
   "ButtonStateless__label--clicked": "ButtonStateless__label--clicked",
   "ButtonStateless__label--active": "ButtonStateless__label--active",

--- a/src/packages/bem/__tests__/dummy-components/index.js
+++ b/src/packages/bem/__tests__/dummy-components/index.js
@@ -1,2 +1,4 @@
 export { default as Button } from './Button';
 export { default as ButtonStateless } from './ButtonStateless';
+export { default as Avatar } from './Avatar';
+export { default as AvatarStateless } from './AvatarStateless';

--- a/src/packages/bem/bem.js
+++ b/src/packages/bem/bem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { buildBemProps, getFunctionName } from './bemUtils';
+import { buildBemProps, getFunctionName, isBlockDecl } from './bemUtils';
 
 /**
  * CSS modules classnames map
@@ -43,7 +43,7 @@ function bemStateful(classnamesMap) {
          * @returns {BEMClassNames}
          */
         // eslint-disable-next-line no-param-reassign
-        StatefulBemComponent.prototype.block = function block() {
+        StatefulBemComponent.prototype.block = function block(extraMods = {}) {
             return buildBemProps({
                 block: blockName,
                 elem: null,
@@ -51,6 +51,7 @@ function bemStateful(classnamesMap) {
                 propsToMods,
                 state: this.state,
                 stateToMods,
+                extraMods,
                 classnamesMap
             });
         };
@@ -60,7 +61,7 @@ function bemStateful(classnamesMap) {
          * @returns {BEMClassNames}
          */
         // eslint-disable-next-line no-param-reassign
-        StatefulBemComponent.prototype.elem = function elem(elemName) {
+        StatefulBemComponent.prototype.elem = function elem(elemName, extraMods = {}) {
             return buildBemProps({
                 block: blockName,
                 elem: elemName,
@@ -68,6 +69,7 @@ function bemStateful(classnamesMap) {
                 propsToMods,
                 state: this.state,
                 stateToMods,
+                extraMods,
                 classnamesMap
             });
         };
@@ -84,7 +86,7 @@ function bemStateful(classnamesMap) {
 function bemStateless(blockDecl) {
     const { name, classnames, propsToMods } = blockDecl;
     return {
-        block: props => {
+        block: (props, extraMods = {}) => {
             if (!props) {
                 throw new TypeError('block(props) should be called with props as an argument');
             }
@@ -93,10 +95,11 @@ function bemStateless(blockDecl) {
                 elem: null,
                 props,
                 propsToMods,
+                extraMods,
                 classnamesMap: classnames
             });
         },
-        elem: (elemName, props) => {
+        elem: (elemName, props, extraMods = {}) => {
             if (!elemName || !props) {
                 throw new TypeError(
                     'elem(elemName, props) should be called with elem name and props as an arguments'
@@ -107,6 +110,7 @@ function bemStateless(blockDecl) {
                 elem: elemName,
                 props,
                 propsToMods,
+                extraMods,
                 classnamesMap: classnames
             });
         }
@@ -121,7 +125,7 @@ function bemStateless(blockDecl) {
  */
 export default function bem(args) {
     // bem was called as a in stateless mode
-    if (typeof args.name === 'string' && args.name !== '' && typeof args.classnames === 'object') {
+    if (isBlockDecl(args)) {
         const { name, classnames, propsToMods } = args;
         return bemStateless({ name, classnames, propsToMods });
     }

--- a/src/packages/bem/bemUtils.js
+++ b/src/packages/bem/bemUtils.js
@@ -40,7 +40,7 @@ function buildModsFromObject(source, modNames) {
         const propValue = source[modNames];
 
         if (propValue) {
-            if (propValue && typeof propValue === 'string') {
+            if (propValue && (typeof propValue === 'string' || typeof propValue === 'number')) {
                 result[modNames] = propValue; // eslint-disable-line no-param-reassign
             }
 

--- a/src/packages/bem/bemUtils.js
+++ b/src/packages/bem/bemUtils.js
@@ -86,12 +86,28 @@ function buildModClassName({ block, elem = null, modName, modValue }) {
  * @returns {ClassnamesMap}
  */
 function modsToClassNames(block, elem = null, mods, classnamesMap) {
-    return Object.keys(mods)
-        .map(modName => {
-            const classKey = buildModClassName({ block, elem, modName, modValue: mods[modName] });
-            return classnamesMap[classKey];
-        })
-        .filter(className => className);
+    const classNames = [];
+    Object.keys(mods).forEach(modName => {
+        const modValue = mods[modName];
+
+        // Checking if we should produce a "wildcard" class name for the current modifier
+        // E.g. Component--size
+        if (typeof modValue === 'string' || typeof modValue === 'number') {
+            const wildcardClassKey = buildModClassName({ block, elem, modName, modValue: true });
+            if (classnamesMap[wildcardClassKey]) {
+                classNames.push(classnamesMap[wildcardClassKey]);
+            }
+        }
+
+        // Checking if there is specific class name defined
+        // E.g. Component--size_2
+        const classKey = buildModClassName({ block, elem, modName, modValue });
+        if (classnamesMap[classKey]) {
+            classNames.push(classnamesMap[classKey]);
+        }
+    });
+
+    return classNames;
 }
 
 /**

--- a/src/packages/bem/bemUtils.js
+++ b/src/packages/bem/bemUtils.js
@@ -154,7 +154,7 @@ function checkModsDeclaration(block, source, declarations) {
         if (declaration in source === false) {
             // eslint-disable-next-line no-console
             console.warn(
-                `BEM component "${block}" prabably has incorrect declaration of "${declaration}"`
+                `BEM component "${block}" probably has incorrect declaration of "${declaration}"`
             );
         }
     });

--- a/src/packages/bem/bemUtils.js
+++ b/src/packages/bem/bemUtils.js
@@ -108,9 +108,11 @@ function getFunctionNameFallback(func) {
  * Builds a full list of class names for a block or an element
  * @param {string} block – Block name
  * @param {string} [elem] – Elem name
- * @param {ModsList} propsToMods
- * @param {ModsList} stateToMods
- * @param {ModDict} props
+ * @param {ModDict} props - All props from a component
+ * @param {ModsList} propsToMods - List of props properties to use for class generation
+ * @param {ModDict} state - All state from a component
+ * @param {ModsList} stateToMods - List of state properties to use for class generation
+ * @param {ModDict} extraMods - Extra mods that are not related to props or state
  * @param {ClassnamesMap} classnamesMap - css modules classnames map
  * @returns {string}
  * @public
@@ -122,12 +124,15 @@ function buildClassNames({
     propsToMods,
     state,
     stateToMods,
+    extraMods,
     classnamesMap
 }) {
     const blockElemName = elem ? `${block}${ELEM_SEPARATOR}${elem}` : block;
     const modsFromProps = buildModsFromObject(props, propsToMods);
     const modsFromState = buildModsFromObject(state, stateToMods);
-    const mods = Object.assign({}, modsFromProps, modsFromState);
+
+    // Todo: check that modsFromProps, modsFromState, extraMods don't have any intersections
+    const mods = Object.assign({}, modsFromProps, modsFromState, extraMods);
 
     // Base level
     const baseClassName = classnamesMap[blockElemName];
@@ -156,6 +161,16 @@ function checkModsDeclaration(block, source, declarations) {
 }
 
 /**
+ * Tells if args has a shape of BlockDecl
+ * @param {Object} args – Arbitrary object to check
+ * @returns {}
+ * @public
+ */
+export function isBlockDecl(args) {
+    return typeof args.name === 'string' && args.name !== '' && typeof args.classnames === 'object';
+}
+
+/**
  * Builds an object of props that will be spreaded through block or elements
  * @param {string} block
  * @param {string} [elem]
@@ -163,6 +178,7 @@ function checkModsDeclaration(block, source, declarations) {
  * @param {ModsList} [propsToMods]
  * @param {ModDict} [state]
  * @param {ModsList} [stateToMods]
+ * @param {ModDict} [extraMods]
  * @param {ClassnamesMap} classnamesMap
  * @returns {BEMClassNames}
  * @public
@@ -174,6 +190,7 @@ export function buildBemProps({
     propsToMods = [],
     state = {},
     stateToMods = [],
+    extraMods = {},
     classnamesMap
 }) {
     // If we deal with a new block, checking propsToMods and stateToMods declarations
@@ -189,6 +206,7 @@ export function buildBemProps({
         propsToMods,
         state,
         stateToMods,
+        extraMods,
         classnamesMap
     });
 


### PR DESCRIPTION
- Fix bug in bem.js about building classnames with numeric mods
- Address a way of creating modifiers that do not depend neither of props nor of state
- Add ability to define "wildcard" class name for modifier (applied if modifier has any value)
- Fix type