### PR TITLE
LoadingSpinner and ProgressBar: Use children instead of label prop

### DIFF
--- a/src/components/LoadingSpinner/LoadingSpinner.js
+++ b/src/components/LoadingSpinner/LoadingSpinner.js
@@ -12,7 +12,7 @@ const { block, elem } = bem({
 });
 
 const LoadingSpinner = props => {
-    const { centerIn, context, hidden, label, size, ...rest } = props;
+    const { centerIn, children, context, hidden, size, ...rest } = props;
     return (
         <div {...rest} {...block(props)}>
             <svg
@@ -37,9 +37,9 @@ const LoadingSpinner = props => {
                     {...elem('path', props)}
                 />
             </svg>
-            {!!label && (
+            {!!children && (
                 <Text inline {...elem('label', props)}>
-                    {label}
+                    {children}
                 </Text>
             )}
         </div>
@@ -51,21 +51,21 @@ LoadingSpinner.displayName = 'LoadingSpinner';
 LoadingSpinner.propTypes = {
     /** Center the spinner relative to parent element or viewport */
     centerIn: PropTypes.oneOf(['parent', 'viewport']),
+    /** Loading text */
+    children: PropTypes.node,
     /** The spinner context (e.g. brand, primary, bad, good etc. - defaults to brand) */
     context: PropTypes.oneOf(CONTEXTS),
     /** Hides the spinner when true */
     hidden: PropTypes.bool,
-    /** Loading text */
-    label: PropTypes.node,
     /** Custom spinner size (will affect both width and height) */
     size: PropTypes.number
 };
 
 LoadingSpinner.defaultProps = {
     centerIn: null,
+    children: null,
     context: 'brand',
     hidden: false,
-    label: null,
     size: null
 };
 

--- a/src/components/LoadingSpinner/__tests__/LoadingSpinner.spec.js
+++ b/src/components/LoadingSpinner/__tests__/LoadingSpinner.spec.js
@@ -9,7 +9,7 @@ describe('<LoadingSpinner> that renders a circular loading spinner', () => {
     });
 
     it('should render a spinner with label', () => {
-        const wrapper = shallow(<LoadingSpinner label="Loading..." />);
+        const wrapper = shallow(<LoadingSpinner>Loading...</LoadingSpinner>);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 

--- a/src/components/ProgressBar/ProgressBar.js
+++ b/src/components/ProgressBar/ProgressBar.js
@@ -11,7 +11,7 @@ const { block, elem } = bem({
 });
 
 const ProgressBar = props => {
-    const { animated, context, hidden, label, percentage, small, ...rest } = props;
+    const { animated, children, context, hidden, percentage, small, ...rest } = props;
     const percentageAdjusted = Math.max(0, Math.min(percentage, 100));
 
     return (
@@ -22,7 +22,7 @@ const ProgressBar = props => {
                     width: `${percentageAdjusted}%`
                 }}
             >
-                {!small && (label || `${Number(percentageAdjusted)}%`)}
+                {!small && (children || `${Number(percentageAdjusted)}%`)}
             </div>
         </div>
     );
@@ -33,22 +33,23 @@ ProgressBar.displayName = 'ProgressBar';
 ProgressBar.propTypes = {
     /** Show progress activity with animation */
     animated: PropTypes.bool,
+    /** Text to show instead of percentage */
+    children: PropTypes.node,
     /** The progress bar context (e.g. brand, primary, bad, good etc. - defaults to brand) */
     context: PropTypes.oneOf(CONTEXTS),
     /** Hides the progress bar if true */
     hidden: PropTypes.bool,
-    /** Text to show instead of percentage */
-    label: PropTypes.node,
     /** Percentage of progress bar to be filled */
     percentage: PropTypes.number.isRequired,
+    /** Renders a narrow bar without label or percentage */
     small: PropTypes.bool
 };
 
 ProgressBar.defaultProps = {
     animated: false,
+    children: null,
     context: 'brand',
     hidden: false,
-    label: null,
     small: false
 };
 

--- a/src/components/ProgressBar/__tests__/ProgressBar.spec.js
+++ b/src/components/ProgressBar/__tests__/ProgressBar.spec.js
@@ -9,7 +9,7 @@ describe('<ProgressBar> that renders a horizontal progress bar', () => {
     });
 
     it('should render a progress bar with label', () => {
-        const wrapper = shallow(<ProgressBar percentage={25} label="Loading..." />);
+        const wrapper = shallow(<ProgressBar percentage={25}>Loading...</ProgressBar>);
 
         // Check that label is shown
         expect(wrapper.childAt(0).text()).toBe('Loading...');

--- a/stories/LoadingSpinner.js
+++ b/stories/LoadingSpinner.js
@@ -19,7 +19,8 @@ storiesOf('LoadingSpinner', module)
             )}
             context={select('Context', CONTEXTS, CONTEXTS[1])}
             hidden={boolean('Hidden', false)}
-            label={text('Label', 'Loading...')}
             size={number('Size', null)}
-        />
+        >
+            {text('Label', 'Loading...')}
+        </LoadingSpinner>
     ));

--- a/stories/ProgressBar.js
+++ b/stories/ProgressBar.js
@@ -11,8 +11,9 @@ storiesOf('ProgressBar', module)
             animated={boolean('Animated', true)}
             context={select('Context', CONTEXTS, CONTEXTS[1])}
             hidden={boolean('Hidden', false)}
-            label={text('Label', 'Loading...')}
             percentage={number('Percentage', 50)}
             small={boolean('Small', false)}
-        />
+        >
+            {text('Label', 'Loading...')}
+        </ProgressBar>
     ));


### PR DESCRIPTION
* Change `LoadingSpinner` and `ProgressBar` to take their user-defined label from `children` prop instead of `label` (to be removed)