### PR TITLE
Storybook: ignore import/no-extraneous-dependencies

### DIFF
--- a/stories/.eslintrc.json
+++ b/stories/.eslintrc.json
@@ -2,6 +2,7 @@
     "overrides": [{
         "files": ["*.js"],
         "rules": {
+            "import/no-extraneous-dependencies": 0,
             "no-console": 0
         }
     }]

--- a/stories/Alert.js
+++ b/stories/Alert.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 import { Alert } from '@textkernel/oneui';
 import { CONTEXTS } from '@textkernel/oneui/constants';
 

--- a/stories/Button.js
+++ b/stories/Button.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 import { Button } from '@textkernel/oneui';
 import { CONTEXTS, SIZES } from '../src/constants';
 

--- a/stories/ButtonGroup.js
+++ b/stories/ButtonGroup.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, select, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 import { Button, ButtonGroup } from '@textkernel/oneui';
 import { SIZES } from '@textkernel/oneui/constants';
 

--- a/stories/CandidateAvatar.js
+++ b/stories/CandidateAvatar.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, number, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, number, text, withKnobs } from '@storybook/addon-knobs';
 import { CandidateAvatar } from '@textkernel/oneui';
 
 storiesOf('CandidateAvatar', module)

--- a/stories/Checkbox.js
+++ b/stories/Checkbox.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { Checkbox } from '@textkernel/oneui';
 
 storiesOf('Checkbox', module)

--- a/stories/Footer.js
+++ b/stories/Footer.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { text, withKnobs } from '@storybook/addon-knobs';
 import { Footer } from '@textkernel/oneui';
 
 storiesOf('Footer', module)

--- a/stories/Header.js
+++ b/stories/Header.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { text, withKnobs } from '@storybook/addon-knobs';
 import { Header, IconTextkernel } from '@textkernel/oneui';
 
 storiesOf('Header', module)

--- a/stories/Heading.js
+++ b/stories/Heading.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { select, text, withKnobs } from '@storybook/addon-knobs';
 import { Heading } from '@textkernel/oneui';
 import { HEADING_SIZES } from '@textkernel/oneui/constants';
 

--- a/stories/Icon.js
+++ b/stories/Icon.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { select, number, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { select, number, text, withKnobs } from '@storybook/addon-knobs';
 import {
     Heading,
     IconExtract,

--- a/stories/Input.js
+++ b/stories/Input.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 import { Input } from '@textkernel/oneui';
 import { CONTEXTS, INPUT_TYPES, SIZES } from '@textkernel/oneui/constants';
 

--- a/stories/Link.js
+++ b/stories/Link.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { text, withKnobs } from '@storybook/addon-knobs';
 import { Link } from '@textkernel/oneui';
 
 storiesOf('Link', module)

--- a/stories/LoadingSpinner.js
+++ b/stories/LoadingSpinner.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, number, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, number, select, text, withKnobs } from '@storybook/addon-knobs';
 import { LoadingSpinner } from '@textkernel/oneui';
 import { CONTEXTS } from '@textkernel/oneui/constants';
 

--- a/stories/Navigation.js
+++ b/stories/Navigation.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { BrowserRouter, NavLink } from 'react-router-dom'; // eslint-disable-line import/no-extraneous-dependencies
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { BrowserRouter, NavLink } from 'react-router-dom';
+import { storiesOf } from '@storybook/react';
+import { boolean, withKnobs } from '@storybook/addon-knobs';
 import { NavBar, NavItem } from '@textkernel/oneui';
 
 storiesOf('Navigation', module)

--- a/stories/ProgressBar.js
+++ b/stories/ProgressBar.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, number, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, number, select, text, withKnobs } from '@storybook/addon-knobs';
 import { ProgressBar } from '@textkernel/oneui';
 import { CONTEXTS } from '@textkernel/oneui/constants';
 

--- a/stories/RadioButton.js
+++ b/stories/RadioButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { RadioButton } from '@textkernel/oneui';
 
 storiesOf('RadioButton', module)

--- a/stories/Tabs.js
+++ b/stories/Tabs.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, select, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 import { Tab, Tabs, TabContent, TabItem, TabMenu } from '@textkernel/oneui';
 
 const tabs = [

--- a/stories/Text.js
+++ b/stories/Text.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, text, select, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, text, select, withKnobs } from '@storybook/addon-knobs';
 import { Text } from '@textkernel/oneui';
 
 storiesOf('Text', module)

--- a/stories/TextArea.js
+++ b/stories/TextArea.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 import { TextArea } from '@textkernel/oneui';
 import { CONTEXTS, SIZES } from '@textkernel/oneui/constants';
 


### PR DESCRIPTION
* Adds and disables `import/no-extraneous-dependencies` in `stories/.eslintrc.json` so we don't have to repeat it all over our stories