### PR TITLE
Content placeholder

### DIFF
--- a/src/components/ContentPlaceholder/ContentPlaceholder.js
+++ b/src/components/ContentPlaceholder/ContentPlaceholder.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import bem from 'bem';
+import styles from './ContentPlaceholder.scss';
+
+const { block, elem } = bem({
+    name: 'ContentPlaceholder',
+    classnames: styles,
+    propsToMods: []
+});
+
+const calcDuration = seconds => {
+    if (!seconds) {
+        return null;
+    }
+
+    return `${seconds}s`;
+};
+
+const calcMaskWidth = width => {
+    if (!width) {
+        return null;
+    }
+
+    return {
+        width: `${100 - Math.max(Math.min(width, 100), 0)}%`
+    };
+};
+
+const ContentPlaceholder = props => {
+    const { duration, height, width, ...rest } = props;
+
+    return (
+        <div
+            {...rest}
+            {...block(props)}
+            style={{
+                animationDuration: calcDuration(duration),
+                height
+            }}
+        >
+            <div {...elem('mask', props)} style={calcMaskWidth(width)}>
+                &nbsp;
+            </div>
+        </div>
+    );
+};
+
+ContentPlaceholder.displayName = 'ContentPlaceholder';
+
+ContentPlaceholder.propTypes = {
+    /** Animation duration in seconds */
+    duration: PropTypes.number,
+    /** Custom height in pixels for the content placeholder */
+    height: PropTypes.number,
+    /** Width of the content placeholder, relative to its parent */
+    width: PropTypes.number
+};
+
+ContentPlaceholder.defaultProps = {
+    duration: 1,
+    height: null,
+    width: 100
+};
+
+export default ContentPlaceholder;

--- a/src/components/ContentPlaceholder/ContentPlaceholder.js
+++ b/src/components/ContentPlaceholder/ContentPlaceholder.js
@@ -56,9 +56,9 @@ ContentPlaceholder.propTypes = {
 };
 
 ContentPlaceholder.defaultProps = {
-    duration: 1,
+    duration: null,
     height: null,
-    width: 100
+    width: null
 };
 
 export default ContentPlaceholder;

--- a/src/components/ContentPlaceholder/ContentPlaceholder.js
+++ b/src/components/ContentPlaceholder/ContentPlaceholder.js
@@ -6,26 +6,14 @@ import styles from './ContentPlaceholder.scss';
 const { block, elem } = bem({
     name: 'ContentPlaceholder',
     classnames: styles,
-    propsToMods: []
+    propsToMods: ['withoutMargin']
 });
 
-const calcDuration = seconds => {
-    if (!seconds) {
-        return null;
-    }
+const calcDuration = seconds => `${seconds}s`;
 
-    return `${seconds}s`;
-};
-
-const calcMaskWidth = width => {
-    if (!width) {
-        return null;
-    }
-
-    return {
-        width: `${100 - Math.max(Math.min(width, 100), 0)}%`
-    };
-};
+const calcMaskWidth = width => ({
+    width: `${100 - Math.max(Math.min(width, 100), 0)}%`
+});
 
 const ContentPlaceholder = props => {
     const { duration, height, width, ...rest } = props;
@@ -53,13 +41,16 @@ ContentPlaceholder.propTypes = {
     /** Custom height in pixels for the content placeholder */
     height: PropTypes.number,
     /** Width of the content placeholder, relative to its parent */
-    width: PropTypes.number
+    width: PropTypes.number,
+    /** Renders placeholder without its default margin */
+    withoutMargin: PropTypes.bool
 };
 
 ContentPlaceholder.defaultProps = {
-    duration: null,
+    duration: 1,
     height: null,
-    width: null
+    width: 100,
+    withoutMargin: false
 };
 
 export default ContentPlaceholder;

--- a/src/components/ContentPlaceholder/ContentPlaceholder.js
+++ b/src/components/ContentPlaceholder/ContentPlaceholder.js
@@ -16,7 +16,7 @@ const calcMaskWidth = width => ({
 });
 
 const ContentPlaceholder = props => {
-    const { duration, height, width, ...rest } = props;
+    const { duration, height, width, withoutMargin, ...rest } = props;
 
     return (
         <div

--- a/src/components/ContentPlaceholder/ContentPlaceholder.js
+++ b/src/components/ContentPlaceholder/ContentPlaceholder.js
@@ -39,9 +39,7 @@ const ContentPlaceholder = props => {
                 height
             }}
         >
-            <div {...elem('mask', props)} style={calcMaskWidth(width)}>
-                &nbsp;
-            </div>
+            <div {...elem('mask', props)} style={calcMaskWidth(width)} />
         </div>
     );
 };

--- a/src/components/ContentPlaceholder/ContentPlaceholder.js
+++ b/src/components/ContentPlaceholder/ContentPlaceholder.js
@@ -39,6 +39,7 @@ const ContentPlaceholder = props => {
                 height
             }}
         >
+            &nbsp;
             <div {...elem('mask', props)} style={calcMaskWidth(width)} />
         </div>
     );

--- a/src/components/ContentPlaceholder/ContentPlaceholder.scss
+++ b/src/components/ContentPlaceholder/ContentPlaceholder.scss
@@ -16,16 +16,16 @@
         name: shimmer;
         timing-function: linear;
     }
-    line-height: normal;
-    height: 15px;
+    line-height: inherit;
+    height: auto;
     width: 100%;
     background: var(--color-neutral-25);
     background: linear-gradient(to right, var(--color-neutral-10) 5%, var(--color-neutral-25) 15%, var(--color-neutral-10) 30%);
     background-size: 200% 100%;
     position: relative;
     display: flex;
-    flex-direction: row-reverse;
-    margin: var(--spacing-2x) 0;
+    flex-direction: row;
+    justify-content: flex-end;
 
     &__mask {
         background-color: white;

--- a/src/components/ContentPlaceholder/ContentPlaceholder.scss
+++ b/src/components/ContentPlaceholder/ContentPlaceholder.scss
@@ -16,9 +16,8 @@
         name: shimmer;
         timing-function: linear;
     }
+    margin-bottom: var(--spacing-2x);
     line-height: inherit;
-    height: auto;
-    width: 100%;
     background: var(--color-neutral-25);
     background: linear-gradient(to right, var(--color-neutral-10) 5%, var(--color-neutral-25) 15%, var(--color-neutral-10) 30%);
     background-size: 200% 100%;
@@ -31,5 +30,9 @@
         background-color: var(--color-background);
         height: inherit;
         width: 0;
+    }
+    
+    &--withoutMargin {
+        margin-bottom: 0;
     }
 }

--- a/src/components/ContentPlaceholder/ContentPlaceholder.scss
+++ b/src/components/ContentPlaceholder/ContentPlaceholder.scss
@@ -28,7 +28,7 @@
     justify-content: flex-end;
 
     &__mask {
-        background-color: white;
+        background-color: var(--color-background);
         height: inherit;
         width: 0;
     }

--- a/src/components/ContentPlaceholder/ContentPlaceholder.scss
+++ b/src/components/ContentPlaceholder/ContentPlaceholder.scss
@@ -1,0 +1,35 @@
+@keyframes shimmer {
+    0% {
+        background-position: 100% 0;
+    }
+
+    100% {
+        background-position: -100% 0;
+    }
+}
+
+.ContentPlaceholder {
+    animation:{
+        duration: 1s;
+        fill-mode: forwards;
+        iteration-count: infinite;
+        name: shimmer;
+        timing-function: linear;
+    }
+    line-height: normal;
+    height: 15px;
+    width: 100%;
+    background: var(--color-neutral-25);
+    background: linear-gradient(to right, var(--color-neutral-10) 5%, var(--color-neutral-25) 15%, var(--color-neutral-10) 30%);
+    background-size: 200% 100%;
+    position: relative;
+    display: flex;
+    flex-direction: row-reverse;
+    margin: var(--spacing-2x) 0;
+
+    &__mask {
+        background-color: white;
+        height: inherit;
+        width: 0;
+    }
+}

--- a/src/components/ContentPlaceholder/__tests__/ContentPlaceholder.spec.js
+++ b/src/components/ContentPlaceholder/__tests__/ContentPlaceholder.spec.js
@@ -10,7 +10,7 @@ describe('<ContentPlaceholder> that renders a content placeholder', () => {
             animationDuration: null,
             height: null
         });
-        expect(wrapper.childAt(0).props().style).toBeNull();
+        expect(wrapper.childAt(1).props().style).toBeNull();
     });
 
     it('should affect styles when props are changed', () => {
@@ -21,7 +21,7 @@ describe('<ContentPlaceholder> that renders a content placeholder', () => {
             height: 30
         });
 
-        expect(wrapper.childAt(0).props().style).toEqual({
+        expect(wrapper.childAt(1).props().style).toEqual({
             width: '40%'
         });
     });

--- a/src/components/ContentPlaceholder/__tests__/ContentPlaceholder.spec.js
+++ b/src/components/ContentPlaceholder/__tests__/ContentPlaceholder.spec.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import toJson from 'enzyme-to-json';
+import ContentPlaceholder from '../ContentPlaceholder';
+
+describe('<ContentPlaceholder> that renders a content placeholder', () => {
+    it('should render default placeholder', () => {
+        const wrapper = shallow(<ContentPlaceholder />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(wrapper.props().style).toEqual({
+            animationDuration: null,
+            height: null
+        });
+        expect(wrapper.childAt(0).props().style).toBeNull();
+    });
+
+    it('should affect styles when props are changed', () => {
+        const wrapper = shallow(<ContentPlaceholder duration={3} height={30} width={60} />);
+
+        expect(wrapper.props().style).toEqual({
+            animationDuration: '3s',
+            height: 30
+        });
+
+        expect(wrapper.childAt(0).props().style).toEqual({
+            width: '40%'
+        });
+    });
+});

--- a/src/components/ContentPlaceholder/__tests__/ContentPlaceholder.spec.js
+++ b/src/components/ContentPlaceholder/__tests__/ContentPlaceholder.spec.js
@@ -7,14 +7,18 @@ describe('<ContentPlaceholder> that renders a content placeholder', () => {
         const wrapper = shallow(<ContentPlaceholder />);
         expect(toJson(wrapper)).toMatchSnapshot();
         expect(wrapper.props().style).toEqual({
-            animationDuration: null,
+            animationDuration: '1s',
             height: null
         });
-        expect(wrapper.childAt(1).props().style).toBeNull();
+        expect(wrapper.childAt(1).props().style).toEqual({
+            width: '0%'
+        });
     });
 
     it('should affect styles when props are changed', () => {
-        const wrapper = shallow(<ContentPlaceholder duration={3} height={30} width={60} />);
+        const wrapper = shallow(
+            <ContentPlaceholder duration={3} height={30} width={60} withoutMargin />
+        );
 
         expect(wrapper.props().style).toEqual({
             animationDuration: '3s',
@@ -24,5 +28,7 @@ describe('<ContentPlaceholder> that renders a content placeholder', () => {
         expect(wrapper.childAt(1).props().style).toEqual({
             width: '40%'
         });
+
+        expect(wrapper.hasClass('ContentPlaceholder--withoutMargin')).toBe(true);
     });
 });

--- a/src/components/ContentPlaceholder/__tests__/__snapshots__/ContentPlaceholder.spec.js.snap
+++ b/src/components/ContentPlaceholder/__tests__/__snapshots__/ContentPlaceholder.spec.js.snap
@@ -9,7 +9,6 @@ exports[`<ContentPlaceholder> that renders a content placeholder should render d
       "height": null,
     }
   }
-  withoutMargin={false}
 >
    
   <div

--- a/src/components/ContentPlaceholder/__tests__/__snapshots__/ContentPlaceholder.spec.js.snap
+++ b/src/components/ContentPlaceholder/__tests__/__snapshots__/ContentPlaceholder.spec.js.snap
@@ -5,15 +5,20 @@ exports[`<ContentPlaceholder> that renders a content placeholder should render d
   className="ContentPlaceholder"
   style={
     Object {
-      "animationDuration": null,
+      "animationDuration": "1s",
       "height": null,
     }
   }
+  withoutMargin={false}
 >
    
   <div
     className="ContentPlaceholder__mask"
-    style={null}
+    style={
+      Object {
+        "width": "0%",
+      }
+    }
   />
 </div>
 `;

--- a/src/components/ContentPlaceholder/__tests__/__snapshots__/ContentPlaceholder.spec.js.snap
+++ b/src/components/ContentPlaceholder/__tests__/__snapshots__/ContentPlaceholder.spec.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ContentPlaceholder> that renders a content placeholder should render default placeholder 1`] = `
+<div
+  className="ContentPlaceholder"
+  style={
+    Object {
+      "animationDuration": null,
+      "height": null,
+    }
+  }
+>
+  <div
+    className="ContentPlaceholder__mask"
+    style={null}
+  />
+</div>
+`;

--- a/src/components/ContentPlaceholder/__tests__/__snapshots__/ContentPlaceholder.spec.js.snap
+++ b/src/components/ContentPlaceholder/__tests__/__snapshots__/ContentPlaceholder.spec.js.snap
@@ -10,6 +10,7 @@ exports[`<ContentPlaceholder> that renders a content placeholder should render d
     }
   }
 >
+   
   <div
     className="ContentPlaceholder__mask"
     style={null}

--- a/src/components/ContentPlaceholder/index.js
+++ b/src/components/ContentPlaceholder/index.js
@@ -1,0 +1,1 @@
+export { default } from './ContentPlaceholder';

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ export { default as Button } from './components/Button';
 export { default as ButtonGroup } from './components/ButtonGroup';
 export { default as CandidateAvatar } from './components/CandidateAvatar';
 export { default as Checkbox } from './components/Checkbox';
+export { default as ContentPlaceholder } from './components/ContentPlaceholder';
 export { default as Footer } from './components/Footer';
 export { default as Header } from './components/Header';
 export { default as Heading } from './components/Heading';

--- a/stories/ContentPlaceholder.js
+++ b/stories/ContentPlaceholder.js
@@ -11,25 +11,22 @@ storiesOf('ContentPlaceholder', module)
 
         return (
             <div style={{ width: number('Container width in pixels', 400) }}>
-                <div style={{ margin: '6px 0', lineHeight: '12px' }}>
-                    <ContentPlaceholder
-                        duration={duration}
-                        height={height}
-                        width={number('Width for placeholder 1', null)}
-                    />
+                <div style={{ lineHeight: '12px' }}>
+                    <ContentPlaceholder duration={duration} height={height} />
                 </div>
-                <div style={{ margin: '6px 0', lineHeight: '14px' }}>
+                <div style={{ lineHeight: '14px' }}>
                     <ContentPlaceholder
                         duration={duration}
                         height={height}
                         width={number('Width for placeholder 2', 55)}
                     />
                 </div>
-                <div style={{ margin: '6px 0', lineHeight: '16px' }}>
+                <div style={{ lineHeight: '16px' }}>
                     <ContentPlaceholder
                         duration={duration}
                         height={height}
                         width={number('Width for placeholder 3', 65)}
+                        withoutMargin
                     />
                 </div>
             </div>

--- a/stories/ContentPlaceholder.js
+++ b/stories/ContentPlaceholder.js
@@ -7,13 +7,25 @@ storiesOf('ContentPlaceholder', module)
     .addDecorator(withKnobs)
     .add('ContentPlaceholder', () => {
         const duration = number('Animation duration in seconds', 1);
-        const height = number('Custom height', 15);
+        const height = number('Custom height in pixels', 15);
 
         return (
-            <div style={{ width: number('Container width', 400) }}>
-                <ContentPlaceholder duration={duration} height={height} />
-                <ContentPlaceholder duration={duration} height={height} width={55} />
-                <ContentPlaceholder duration={duration} height={height} width={65} />
+            <div style={{ width: number('Container width in pixels', 400) }}>
+                <ContentPlaceholder
+                    duration={duration}
+                    height={height}
+                    width={number('Width for placeholder 1', 100)}
+                />
+                <ContentPlaceholder
+                    duration={duration}
+                    height={height}
+                    width={number('Width for placeholder 2', 55)}
+                />
+                <ContentPlaceholder
+                    duration={duration}
+                    height={height}
+                    width={number('Width for placeholder 3', 65)}
+                />
             </div>
         );
     });

--- a/stories/ContentPlaceholder.js
+++ b/stories/ContentPlaceholder.js
@@ -6,7 +6,7 @@ import { ContentPlaceholder } from '@textkernel/oneui';
 storiesOf('ContentPlaceholder', module)
     .addDecorator(withKnobs)
     .add('ContentPlaceholder', () => {
-        const duration = number('Animation duration in seconds', 1);
+        const duration = number('Animation duration in seconds', null);
         const height = number('Custom height in pixels', null);
 
         return (
@@ -15,7 +15,7 @@ storiesOf('ContentPlaceholder', module)
                     <ContentPlaceholder
                         duration={duration}
                         height={height}
-                        width={number('Width for placeholder 1', 100)}
+                        width={number('Width for placeholder 1', null)}
                     />
                 </div>
                 <div style={{ margin: '6px 0', lineHeight: '14px' }}>

--- a/stories/ContentPlaceholder.js
+++ b/stories/ContentPlaceholder.js
@@ -7,25 +7,31 @@ storiesOf('ContentPlaceholder', module)
     .addDecorator(withKnobs)
     .add('ContentPlaceholder', () => {
         const duration = number('Animation duration in seconds', 1);
-        const height = number('Custom height in pixels', 15);
+        const height = number('Custom height in pixels', null);
 
         return (
             <div style={{ width: number('Container width in pixels', 400) }}>
-                <ContentPlaceholder
-                    duration={duration}
-                    height={height}
-                    width={number('Width for placeholder 1', 100)}
-                />
-                <ContentPlaceholder
-                    duration={duration}
-                    height={height}
-                    width={number('Width for placeholder 2', 55)}
-                />
-                <ContentPlaceholder
-                    duration={duration}
-                    height={height}
-                    width={number('Width for placeholder 3', 65)}
-                />
+                <div style={{ margin: '6px 0', lineHeight: '12px' }}>
+                    <ContentPlaceholder
+                        duration={duration}
+                        height={height}
+                        width={number('Width for placeholder 1', 100)}
+                    />
+                </div>
+                <div style={{ margin: '6px 0', lineHeight: '14px' }}>
+                    <ContentPlaceholder
+                        duration={duration}
+                        height={height}
+                        width={number('Width for placeholder 2', 55)}
+                    />
+                </div>
+                <div style={{ margin: '6px 0', lineHeight: '16px' }}>
+                    <ContentPlaceholder
+                        duration={duration}
+                        height={height}
+                        width={number('Width for placeholder 3', 65)}
+                    />
+                </div>
             </div>
         );
     });

--- a/stories/ContentPlaceholder.js
+++ b/stories/ContentPlaceholder.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { number, withKnobs } from '@storybook/addon-knobs';
+import { ContentPlaceholder } from '@textkernel/oneui';
+
+storiesOf('ContentPlaceholder', module)
+    .addDecorator(withKnobs)
+    .add('ContentPlaceholder', () => {
+        const duration = number('Animation duration in seconds', 1);
+        const height = number('Custom height', 15);
+
+        return (
+            <div style={{ width: number('Container width', 400) }}>
+                <ContentPlaceholder duration={duration} height={height} />
+                <ContentPlaceholder duration={duration} height={height} width={55} />
+                <ContentPlaceholder duration={duration} height={height} width={65} />
+            </div>
+        );
+    });

--- a/stories/ContentPlaceholder.js
+++ b/stories/ContentPlaceholder.js
@@ -5,26 +5,45 @@ import { ContentPlaceholder } from '@textkernel/oneui';
 
 storiesOf('ContentPlaceholder', module)
     .addDecorator(withKnobs)
-    .add('ContentPlaceholder', () => {
+    .add('Simple implementation', () => {
         const duration = number('Animation duration in seconds', null);
         const height = number('Custom height in pixels', null);
 
         return (
+            <div style={{ width: 400 }}>
+                <ContentPlaceholder duration={duration} height={height} />
+                <ContentPlaceholder
+                    duration={duration}
+                    height={height}
+                    width={number('Width for placeholder 2', 55)}
+                />
+                <ContentPlaceholder
+                    duration={duration}
+                    height={height}
+                    width={number('Width for placeholder 3', 65)}
+                    withoutMargin
+                />
+            </div>
+        );
+    })
+    .add('Custom implementation', () => {
+        const duration = number('Animation duration in seconds', null);
+
+        return (
             <div style={{ width: number('Container width in pixels', 400) }}>
-                <div style={{ lineHeight: '12px' }}>
-                    <ContentPlaceholder duration={duration} height={height} />
+                <div style={{ lineHeight: '12px', marginBottom: '5px' }}>
+                    <ContentPlaceholder duration={duration} withoutMargin />
                 </div>
-                <div style={{ lineHeight: '14px' }}>
+                <div style={{ lineHeight: '14px', marginBottom: '5px' }}>
                     <ContentPlaceholder
                         duration={duration}
-                        height={height}
                         width={number('Width for placeholder 2', 55)}
+                        withoutMargin
                     />
                 </div>
                 <div style={{ lineHeight: '16px' }}>
                     <ContentPlaceholder
                         duration={duration}
-                        height={height}
                         width={number('Width for placeholder 3', 65)}
                         withoutMargin
                     />

--- a/stories/index.js
+++ b/stories/index.js
@@ -3,6 +3,7 @@ import './Button';
 import './ButtonGroup';
 import './CandidateAvatar';
 import './Checkbox';
+import './ContentPlaceholder';
 import './Footer';
 import './Header';
 import './Heading';


### PR DESCRIPTION
Adds a simple `ContentPlaceholder` component

* `height`: Variable placeholder height in pixels. When not set, it will inherit `lineHeight` by default.
* `width`: Variable placeholder width, relative to the parent container. When not set, it will default to `100%`.
* `duration`: Custom animation duration in seconds. When not set, it will default to `1s`.

The component is to be used inside a block-level parent element (or an element that has a width defined).