### PR TITLE
Replace uglifyjs-webpack-plugin with terser-webpack-plugin

### DIFF
--- a/etc/webpack/webpack.prod.config.js
+++ b/etc/webpack/webpack.prod.config.js
@@ -1,4 +1,4 @@
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin'); // eslint-disable-line import/no-extraneous-dependencies
+const TerserPlugin = require('terser-webpack-plugin'); // eslint-disable-line import/no-extraneous-dependencies
 const { baseConfig, plugins, getRules } = require('./webpack.config');
 
 const rules = getRules('prod');
@@ -17,8 +17,8 @@ module.exports = {
     },
     optimization: {
         minimizer: [
-            new UglifyJsPlugin({
-                uglifyOptions: {
+            new TerserPlugin({
+                terserOptions: {
                     mangle: false
                 }
             })

--- a/package-lock.json
+++ b/package-lock.json
@@ -23406,20 +23406,20 @@
             }
         },
         "terser": {
-            "version": "3.11.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-3.11.0.tgz",
-            "integrity": "sha512-5iLMdhEPIq3zFWskpmbzmKwMQixKmTYwY3Ox9pjtSklBLnHiuQ0GKJLhL1HSYtyffHM3/lDIFBnb82m9D7ewwQ==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+            "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
             "dev": true,
             "requires": {
-                "commander": "~2.17.1",
+                "commander": "^2.19.0",
                 "source-map": "~0.6.1",
-                "source-map-support": "~0.5.6"
+                "source-map-support": "~0.5.10"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.17.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-                    "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+                    "version": "2.19.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+                    "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
                     "dev": true
                 },
                 "source-map": {
@@ -23427,23 +23427,13 @@
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
-                },
-                "source-map-support": {
-                    "version": "0.5.9",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-                    "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-                    "dev": true,
-                    "requires": {
-                        "buffer-from": "^1.0.0",
-                        "source-map": "^0.6.0"
-                    }
                 }
             }
         },
         "terser-webpack-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.1.0.tgz",
-            "integrity": "sha512-61lV0DSxMAZ8AyZG7/A4a3UPlrbOBo8NIQ4tJzLPAdGOQ+yoNC7l5ijEow27lBAL2humer01KLS6bGIMYQxKoA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
+            "integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
             "dev": true,
             "requires": {
                 "cacache": "^11.0.2",
@@ -23451,41 +23441,19 @@
                 "schema-utils": "^1.0.0",
                 "serialize-javascript": "^1.4.0",
                 "source-map": "^0.6.1",
-                "terser": "^3.8.1",
+                "terser": "^3.16.1",
                 "webpack-sources": "^1.1.0",
                 "worker-farm": "^1.5.2"
             },
             "dependencies": {
-                "cacache": {
-                    "version": "11.3.1",
-                    "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
-                    "integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
-                    "dev": true,
-                    "requires": {
-                        "bluebird": "^3.5.1",
-                        "chownr": "^1.0.1",
-                        "figgy-pudding": "^3.1.0",
-                        "glob": "^7.1.2",
-                        "graceful-fs": "^4.1.11",
-                        "lru-cache": "^4.1.3",
-                        "mississippi": "^3.0.0",
-                        "mkdirp": "^0.5.1",
-                        "move-concurrently": "^1.0.1",
-                        "promise-inflight": "^1.0.1",
-                        "rimraf": "^2.6.2",
-                        "ssri": "^6.0.0",
-                        "unique-filename": "^1.1.0",
-                        "y18n": "^4.0.0"
-                    }
-                },
                 "find-cache-dir": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
-                    "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+                    "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
                     "dev": true,
                     "requires": {
                         "commondir": "^1.0.1",
-                        "make-dir": "^1.0.0",
+                        "make-dir": "^2.0.0",
                         "pkg-dir": "^3.0.0"
                     }
                 },
@@ -23508,28 +23476,20 @@
                         "path-exists": "^3.0.0"
                     }
                 },
-                "mississippi": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-                    "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
                     "dev": true,
                     "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^3.0.0",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
                     }
                 },
                 "p-limit": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-                    "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
@@ -23545,9 +23505,15 @@
                     }
                 },
                 "p-try": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-                    "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+                    "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+                    "dev": true
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
                     "dev": true
                 },
                 "pkg-dir": {
@@ -23559,35 +23525,16 @@
                         "find-up": "^3.0.0"
                     }
                 },
-                "pump": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-                    "dev": true,
-                    "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                    }
+                "semver": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+                    "dev": true
                 },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "ssri": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-                    "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
-                    "dev": true,
-                    "requires": {
-                        "figgy-pudding": "^3.5.1"
-                    }
-                },
-                "y18n": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
                     "dev": true
                 }
             }
@@ -24028,93 +23975,6 @@
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
                     "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
                     "dev": true
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
-        "uglifyjs-webpack-plugin": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.0.1.tgz",
-            "integrity": "sha512-1HhCHkOB6wRCcv7htcz1QRPVbWPEY074RP9vzt/X0LF4xXm9l4YGd0qja7z88abDixQlnVwBjXsTBs+Xsn/eeQ==",
-            "dev": true,
-            "requires": {
-                "cacache": "^11.2.0",
-                "find-cache-dir": "^2.0.0",
-                "schema-utils": "^1.0.0",
-                "serialize-javascript": "^1.4.0",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.0.0",
-                "webpack-sources": "^1.1.0",
-                "worker-farm": "^1.5.2"
-            },
-            "dependencies": {
-                "find-cache-dir": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
-                    "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
-                    "dev": true,
-                    "requires": {
-                        "commondir": "^1.0.1",
-                        "make-dir": "^1.0.0",
-                        "pkg-dir": "^3.0.0"
-                    }
-                },
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-                    "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "p-try": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-                    "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-                    "dev": true
-                },
-                "pkg-dir": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-                    "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^3.0.0"
-                    }
                 },
                 "source-map": {
                     "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "stylelint-order": "1.0.0",
         "stylelint-scss": "3.3.1",
         "stylelint-webpack-plugin": "0.10.5",
-        "uglifyjs-webpack-plugin": "2.0.1",
+        "terser-webpack-plugin": "1.2.3",
         "webpack": "4.28.1",
         "webpack-cli": "3.2.1",
         "webpack-dev-server": "3.1.14"


### PR DESCRIPTION
It seems `uglifyjs-webpack-plugin` is causing builds that use the React Hooks API to break:

* https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/374
* https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/393
* https://github.com/facebook/react/issues/14014

Also, it's said that the package is not actively maintained and can best be replaced with `terser-webpack-plugin`. Webpack docs [mention Terser too](https://webpack.js.org/guides/production/#minification).

* Replaces devDependency `uglifyjs-webpack-plugin` with `terser-webpack-plugin`, preserving same configuration.