### PR TITLE
feat: forward refs in form components

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import bem from '../../packages/bem';
 import styles from './Button.scss';
@@ -10,23 +10,23 @@ const { block } = bem({
     propsToMods: ['context', 'size', 'isBlock', 'isInline']
 });
 
-const Button = props => {
+const Button = forwardRef((props, ref) => {
     const { children, context, disabled, isBlock, isInline, type, href, ...rest } = props;
 
     if (href) {
         return (
-            <a {...rest} {...block(props)} href={href}>
+            <a {...rest} {...block(props)} ref={ref} href={href}>
                 {children}
             </a>
         );
     }
 
     return (
-        <button {...rest} {...block(props)} type={type} disabled={disabled}>
+        <button {...rest} {...block(props)} ref={ref} type={type} disabled={disabled}>
             {children}
         </button>
     );
-};
+});
 
 Button.displayName = 'Button';
 

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import bem from 'bem';
 import Text from '../Text';
@@ -11,7 +11,7 @@ const { block, elem } = bem({
     propsToMods: ['disabled']
 });
 
-const Checkbox = props => {
+const Checkbox = forwardRef((props, ref) => {
     const { id, children, viewbox, disabled, ...rest } = props;
 
     return (
@@ -19,6 +19,7 @@ const Checkbox = props => {
             <input
                 {...rest}
                 {...elem('input', props)}
+                ref={ref}
                 type="checkbox"
                 id={id}
                 disabled={disabled}
@@ -42,7 +43,7 @@ const Checkbox = props => {
             </label>
         </div>
     );
-};
+});
 
 Checkbox.displayName = 'Checkbox';
 

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import bem from '../../packages/bem';
 import styles from './Input.scss';
@@ -10,10 +10,19 @@ const { block } = bem({
     propsToMods: ['context', 'isBlock', 'size']
 });
 
-const Input = props => {
+const Input = forwardRef((props, ref) => {
     const { children, context, disabled, isBlock, size, type, value, ...rest } = props;
-    return <input {...rest} {...block(props)} type={type} disabled={disabled} value={value} />;
-};
+    return (
+        <input
+            {...rest}
+            {...block(props)}
+            ref={ref}
+            type={type}
+            disabled={disabled}
+            value={value}
+        />
+    );
+});
 
 Input.displayName = 'Input';
 

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import bem from 'bem';
 import Text from '../Text';
@@ -11,7 +11,7 @@ const { block, elem } = bem({
     propsToMods: ['disabled']
 });
 
-const RadioButton = props => {
+const RadioButton = forwardRef((props, ref) => {
     const { id, children, viewbox, disabled, name, ...rest } = props;
 
     return (
@@ -19,6 +19,7 @@ const RadioButton = props => {
             <input
                 {...rest}
                 {...elem('input', props)}
+                ref={ref}
                 type="radio"
                 id={id}
                 name={name}
@@ -43,7 +44,7 @@ const RadioButton = props => {
             </label>
         </div>
     );
-};
+});
 
 RadioButton.displayName = 'RadioButton';
 

--- a/src/components/TextArea/TextArea.js
+++ b/src/components/TextArea/TextArea.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import bem from 'bem';
 import styles from './TextArea.scss';
@@ -10,10 +10,10 @@ const { block } = bem({
     propsToMods: ['context', 'isBlock', 'size']
 });
 
-const TextArea = props => {
+const TextArea = forwardRef((props, ref) => {
     const { context, disabled, isBlock, size, ...rest } = props;
-    return <textarea {...rest} {...block(props)} disabled={disabled} />;
-};
+    return <textarea {...rest} {...block(props)} ref={ref} disabled={disabled} />;
+});
 
 TextArea.displayName = 'TextArea';
 


### PR DESCRIPTION
* Forwards `ref` for `Button`, `Input`, `TextArea`, `RadioButton` and `Checkbox` components to allow accessing rendered DOM element (e.g. to programmatically set focus, determine position / dimensions on screen)

BREAKING CHANGE: Ref forwarding may introduce observably different behavior