### PR TITLE
fix(button): do not apply context as element attribute

### DIFF
--- a/src/components/Alert/__tests__/__snapshots__/Alert.spec.js.snap
+++ b/src/components/Alert/__tests__/__snapshots__/Alert.spec.js.snap
@@ -55,7 +55,6 @@ exports[`<Alert> that renders an alert should have a button that works 1`] = `
       >
         <button
           className="Button Button--context Button--context_link Button--size Button--size_normal"
-          context="link"
           disabled={false}
           onClick={[MockFunction]}
           size="normal"

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -11,7 +11,7 @@ const { block } = bem({
 });
 
 const Button = props => {
-    const { children, disabled, isBlock, isInline, type, ...rest } = props;
+    const { children, context, disabled, isBlock, isInline, type, ...rest } = props;
 
     return (
         <button {...rest} {...block(props)} type={type} disabled={disabled}>

--- a/src/components/Button/__tests__/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.spec.js.snap
@@ -11,7 +11,6 @@ exports[`<Button> that renders a button should add classes when props are change
 >
   <button
     className="Button Button--context Button--context_primary Button--size Button--size_large Button--isBlock"
-    context="primary"
     disabled={false}
     size="large"
     type="button"
@@ -34,7 +33,6 @@ exports[`<Button> that renders a button should render default button correctly 1
 >
   <button
     className="Button Button--context Button--context_neutral Button--size Button--size_normal"
-    context="neutral"
     disabled={false}
     size="normal"
     type="button"

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -20,7 +20,6 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
     >
       <button
         className="Button Button--context Button--context_neutral Button--size Button--size_large ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_large ButtonGroup__button--isBlock"
-        context="neutral"
         disabled={false}
         size="large"
         type="button"
@@ -40,7 +39,6 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
     >
       <button
         className="Button Button--context Button--context_neutral Button--size Button--size_large ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_large ButtonGroup__button--isBlock"
-        context="neutral"
         disabled={false}
         size="large"
         type="button"
@@ -72,7 +70,6 @@ exports[`<ButtonGroup> that renders a button should render default button correc
     >
       <button
         className="Button Button--context Button--context_neutral Button--size Button--size_normal ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_normal"
-        context="neutral"
         disabled={false}
         size="normal"
         type="button"
@@ -92,7 +89,6 @@ exports[`<ButtonGroup> that renders a button should render default button correc
     >
       <button
         className="Button Button--context Button--context_neutral Button--size Button--size_normal ButtonGroup__button ButtonGroup__button--size ButtonGroup__button--size_normal"
-        context="neutral"
         disabled={false}
         size="normal"
         type="button"


### PR DESCRIPTION
The `context` prop was not part of the destructuring assignment, causing it to be applied as an HTML attribute to the rendered `button` element.