### PR TITLE
fix(storybook): reinstate missing knobs for loadingspinner

### DIFF
--- a/stories/LoadingSpinner.js
+++ b/stories/LoadingSpinner.js
@@ -8,6 +8,9 @@ storiesOf('LoadingSpinner', module)
     .addDecorator(withKnobs)
     .add('LoadingSpinner', () => (
         <LoadingSpinner
+            context={select('Context', CONTEXTS, CONTEXTS[1])}
+            hidden={boolean('Hidden', false)}
+            size={number('Size', null)}
             centerIn={select(
                 'Center in...',
                 {
@@ -17,9 +20,6 @@ storiesOf('LoadingSpinner', module)
                 },
                 null
             )}
-            context={select('Context', CONTEXTS, CONTEXTS[1])}
-            hidden={boolean('Hidden', false)}
-            size={number('Size', null)}
         >
             {text('Label', 'Loading...')}
         </LoadingSpinner>


### PR DESCRIPTION
Reinstate all LoadingSpinner storybook knobs that went missing (other than `centerIn`)