### PR TITLE
chore: dont use relative paths for importing bem package

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import bem from '../../packages/bem';
+import bem from 'bem';
 import styles from './Button.scss';
 import { CONTEXTS, SIZES } from '../../constants';
 

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import bem from '../../packages/bem';
+import bem from 'bem';
 import styles from './ButtonGroup.scss';
 import { SIZES } from '../../constants';
 

--- a/src/components/CandidateAvatar/CandidateAvatar.js
+++ b/src/components/CandidateAvatar/CandidateAvatar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import bem from '../../packages/bem';
+import bem from 'bem';
 import styles from './CandidateAvatar.scss';
 
 const { block, elem } = bem({

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import bem from '../../packages/bem';
+import bem from 'bem';
 import styles from './Input.scss';
 import { CONTEXTS, INPUT_TYPES, SIZES } from '../../constants';
 

--- a/src/components/ProgressBar/ProgressBar.js
+++ b/src/components/ProgressBar/ProgressBar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import bem from '../../packages/bem';
+import bem from 'bem';
 import styles from './ProgressBar.scss';
 import { CONTEXTS } from '../../constants';
 


### PR DESCRIPTION
Some components still use relative paths for importing the bem package, which is not necessary. Updated those components.