### PR TITLE
fix(button): fix height issues with anchor-buttons in safari

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -7,6 +7,7 @@
         width: var(--line-normal);
         style: solid;
     }
+    box-sizing: content-box;
     color: var(--color-brand);
     cursor: pointer;
     font: {
@@ -16,6 +17,8 @@
     }
     text-decoration: none;
     line-height: var(--line-height-normal);
+    height: var(--line-height-normal);
+    margin: 0;
     outline: none;
     padding: var(--spacing-2x) var(--spacing-4x);
     text-align: center;


### PR DESCRIPTION
Fix issue with buttons that use `<a />` tags which in Safari have a different height from regular buttons