### PR TITLE
fix(storybook): initialize oneui before loading stories

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,7 @@
 import { configure, addDecorator, addParameters } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { withConsole } from '@storybook/addon-console';
+import OneUI from '@textkernel/oneui';
 import OneUITheme from './oneui.theme';
 
 addDecorator(
@@ -21,4 +22,7 @@ function loadStories() {
     require('../stories/index.js');
 }
 
-configure(loadStories, module);
+OneUI.init().then(() => {
+    configure(loadStories, module);
+});
+


### PR DESCRIPTION
Run `OneUI.init` before loading stories, so css-vars-ponyfill is loaded and styles work in IE11 too