### PR TITLE
fix: remove font specifications from Link

### DIFF
--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -1,11 +1,5 @@
 .Link {
     color: var(--link-color-normal);
-    font: {
-        family: var(--font-family-primary);
-        size: var(--font-size-normal);
-        weight: var(--font-weight-normal);
-    }
-    line-height: var(--line-height-normal);
     text-decoration: var(--link-decoration-normal);
     transition: color var(--transition-duration);
 


### PR DESCRIPTION
Don't set font attributed directly on Link, but let the context determine size and so on.