### PR TITLE
fix: styling for buttongroup with single button

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -7,10 +7,12 @@
         border-radius: 0;
 
         &:first-child {
-            border-radius: var(--border-radius) 0 0 var(--border-radius);
+            border-top-left-radius: var(--border-radius);
+            border-bottom-left-radius: var(--border-radius);
         }
         &:last-child {
-            border-radius: 0 var(--border-radius) var(--border-radius) 0;
+            border-top-right-radius: var(--border-radius);
+            border-bottom-right-radius: var(--border-radius);
         }
 
         + .ButtonGroup__button {


### PR DESCRIPTION
Fix border-radius on the left side of ButtonGroups containing only a single button