### PR TITLE
fix: update default footer copyright

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import bem from 'bem';
 import styles from './Footer.scss';
-import { IconTextkernel } from '../Icon';
+import { LogoTextkernel } from '../Icon';
 
 const { block, elem } = bem({
     name: 'Footer',
@@ -15,8 +15,7 @@ const Footer = props => {
     const tkCopyright = (
         <span>
             {`\u00a9 ${new Date().getFullYear()} `}
-            <IconTextkernel {...elem('logo', props)} />
-            {` Textkernel`}
+            <LogoTextkernel {...elem('logo', props)} margin="left" />
         </span>
     );
 

--- a/src/components/Footer/__tests__/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.spec.js.snap
@@ -30,7 +30,6 @@ exports[`Footer component that renders a copyright text on the left and optional
           >
             <div
               className="IconBase IconBase--margin IconBase--margin_left Footer__logo"
-              margin="left"
             >
               <svg
                 aria-labelledby={null}

--- a/src/components/Footer/__tests__/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.spec.js.snap
@@ -12,46 +12,72 @@ exports[`Footer component that renders a copyright text on the left and optional
     >
       <span>
         © 2019 
-        <IconTextkernel
+        <LogoTextkernel
           className="Footer__logo"
           context={null}
-          margin={null}
+          margin="left"
           size={null}
           title={null}
         >
           <IconBase
             className="Footer__logo"
             context={null}
-            margin={null}
-            preserveAspectRatio={false}
+            margin="left"
+            preserveAspectRatio={true}
             size={null}
             title={null}
-            viewBox="0 0 369.7 800"
+            viewBox="0 0 442.8 77.3"
           >
             <div
-              className="IconBase Footer__logo"
-              margin={null}
+              className="IconBase IconBase--margin IconBase--margin_left Footer__logo"
+              margin="left"
             >
               <svg
                 aria-labelledby={null}
-                className="IconBase__svg"
+                className="IconBase__svg IconBase__svg--margin IconBase__svg--margin_left"
                 role="img"
                 style={
                   Object {
-                    "width": "1em",
+                    "width": "auto",
                   }
                 }
-                viewBox="0 0 369.7 800"
+                viewBox="0 0 442.8 77.3"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M334.3,800C203.4,766.9,89.9,681.8,89.9,543.8V248.3H0v-104H89.9V0H223.1V144.2H349.2v104H223.1V554c0,76.5,56.7,109.6,146.6,130.8Z"
+                  d="M29,77.3C17.6,74.4,7.8,67.1,7.8,55.1V29.4H0v-9h7.8V7.9h11.6v12.5h11v9h-11V56c0,6.7,4.9,9.5,12.7,11.4L29,77.3z"
+                />
+                <path
+                  d="M49.6,48.4c0.9,7.5,4.8,11.7,11.3,11.7c4.4,0,9.7-1.5,14.7-4l3.8,8.9c-5.6,2.6-12.8,3.7-19.3,3.7c-15.2,0-22.7-11.3-22.7-24.3c0-10.9,4.9-25.2,22.2-25.2c16.3,0,22.1,9.6,22.1,29.2H49.6z M59.6,28.1c-3.8,0-9.5,2.3-9.9,12h21C70.1,31.2,65.6,28.1,59.6,28.1z"
+                />
+                <path
+                  d="M119.7,67.4l-10-15.6L98.9,67.4H86.7l16.9-23.7L87.9,20.5h13l9.2,14.7l9.6-14.7h12.1l-16,22.5l16.8,24.4H119.7z"
+                />
+                <path
+                  d="M167.4,77.3c-11.4-2.9-21.2-10.3-21.2-22.3V29.4h-7.8v-9h7.8V7.9h11.6v12.5h11v9h-11V56c0,6.7,4.9,9.5,12.7,11.4L167.4,77.3z"
+                />
+                <path
+                  d="M208.8,67.4l-17-23.5v23.5h-11.6V0h11.6v39l15.4-18.5h12.5l-17,20.3l19.5,26.6H208.8z"
+                />
+                <path
+                  d="M240,48.4c0.9,7.5,4.8,11.7,11.3,11.7c4.4,0,9.7-1.5,14.7-4l3.8,8.9c-5.6,2.6-12.8,3.7-19.3,3.7c-15.2,0-22.7-11.3-22.7-24.3c0-10.9,4.9-25.2,22.3-25.2c16.3,0,22.1,9.6,22.1,29.2H240z M250,28.1c-3.8,0-9.5,2.3-9.9,12h21C260.5,31.2,256,28.1,250,28.1z"
+                />
+                <path
+                  d="M311.5,30.9c-1.7-1.3-4.2-2.9-6.8-2.9c-5.4,0-8.4,8.6-9.5,11.4v28h-11.6V31c0-4.6-0.9-8.1-1.2-10.5H293l1.8,8c1.6-3,6.7-9.4,11.7-9.4c3.9,0,6.2,0.8,8.9,2.3L311.5,30.9z"
+                />
+                <path
+                  d="M352.7,67.4v-30c0-4.6-0.4-9.3-7.3-9.3c-4.8,0-8.1,4.4-10.3,8.8v30.6h-11.6V30.5c0-3.9-0.8-6.7-1.2-9.9H333l1.8,6.2c1.9-2.1,5.9-7.6,12.5-7.6c13.7,0,16.9,8,16.9,18.8v29.5H352.7z"
+                />
+                <path
+                  d="M387.7,48.4c0.9,7.5,4.8,11.7,11.3,11.7c4.4,0,9.7-1.5,14.7-4l3.8,8.9c-5.6,2.6-12.8,3.7-19.3,3.7c-15.2,0-22.7-11.3-22.7-24.3c0-10.9,4.9-25.2,22.3-25.2c16.3,0,22.1,9.6,22.1,29.2H387.7z M397.6,28.1c-3.8,0-9.5,2.3-9.9,12h21C408.2,31.2,403.7,28.1,397.6,28.1z"
+                />
+                <path
+                  d="M431.2,67.4V0h11.6v67.4H431.2z"
                 />
               </svg>
             </div>
           </IconBase>
-        </IconTextkernel>
-         Textkernel
+        </LogoTextkernel>
       </span>
       <div
         className="Footer__menu"

--- a/src/components/Header/__tests__/__snapshots__/Header.spec.js.snap
+++ b/src/components/Header/__tests__/__snapshots__/Header.spec.js.snap
@@ -41,7 +41,6 @@ exports[`Header component that renders a website header with a logo on the left 
           >
             <div
               className="IconBase"
-              margin={null}
             >
               <svg
                 aria-labelledby={null}

--- a/src/components/Icon/IconBase.js
+++ b/src/components/Icon/IconBase.js
@@ -28,7 +28,7 @@ const adjustSize = (size, preserveAspectRatio) => {
 };
 
 const IconBase = props => {
-    const { children, context, size, preserveAspectRatio, title, viewBox, ...rest } = props;
+    const { children, context, margin, size, preserveAspectRatio, title, viewBox, ...rest } = props;
 
     return (
         <div {...rest} {...block(props)}>

--- a/src/components/Icon/__tests__/__snapshots__/IconBase.spec.js.snap
+++ b/src/components/Icon/__tests__/__snapshots__/IconBase.spec.js.snap
@@ -3,7 +3,6 @@
 exports[`<IconBase> that renders an SVG wrapper with all options included should render a default icon 1`] = `
 <div
   className="IconBase IconBase--context IconBase--context_brand IconBase--margin IconBase--margin_right"
-  margin="right"
 >
   <svg
     aria-labelledby="title"

--- a/stories/Footer.js
+++ b/stories/Footer.js
@@ -6,7 +6,7 @@ import { Footer } from '@textkernel/oneui';
 storiesOf('Footer', module)
     .addDecorator(withKnobs)
     .add('Footer', () => (
-        <Footer copyright={text('Alternative copyright', '')}>
+        <Footer copyright={text('Alternative copyright', null)}>
             {text('Left side', 'This is a placeholder for children')}
         </Footer>
     ));


### PR DESCRIPTION
Use TK logo instead of icon and text, also fixes `margin` attribute being applied to IconBase because it is not destructured from props.