### PR TITLE
fix: destruct props that should not be applied as html attributes

### DIFF
--- a/src/components/Alert/__tests__/__snapshots__/Alert.spec.js.snap
+++ b/src/components/Alert/__tests__/__snapshots__/Alert.spec.js.snap
@@ -60,7 +60,6 @@ exports[`<Alert> that renders an alert should have a button that works 1`] = `
           className="Button Button--context_link"
           disabled={false}
           onClick={[MockFunction]}
-          size="normal"
           type="button"
         >
           Click me

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -11,7 +11,7 @@ const { block } = bem({
 });
 
 const Button = forwardRef((props, ref) => {
-    const { children, context, disabled, isBlock, isInline, type, href, ...rest } = props;
+    const { children, context, disabled, isBlock, isInline, type, href, size, ...rest } = props;
 
     if (href) {
         return (

--- a/src/components/Button/__tests__/__snapshots__/Button.spec.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.spec.js.snap
@@ -13,7 +13,6 @@ exports[`<Button> that renders a button should add classes when props are change
   <button
     className="Button Button--context_primary Button--size_large Button--isBlock"
     disabled={false}
-    size="large"
     type="button"
   >
     <span>
@@ -36,7 +35,6 @@ exports[`<Button> that renders a button should render an ancor element if href i
   <a
     className="Button Button--context_neutral"
     href="/"
-    size="normal"
   >
     Click me
   </a>
@@ -56,7 +54,6 @@ exports[`<Button> that renders a button should render default button correctly 1
   <button
     className="Button Button--context_neutral"
     disabled={false}
-    size="normal"
     type="button"
   >
     Click me

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -24,7 +24,6 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
       <button
         className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--isBlock"
         disabled={false}
-        size="large"
         type="button"
       >
         A button
@@ -44,7 +43,6 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
       <button
         className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--isBlock"
         disabled={false}
-        size="large"
         type="button"
       >
         Another button
@@ -78,7 +76,6 @@ exports[`<ButtonGroup> that renders a button should render default button correc
       <button
         className="Button Button--context_neutral ButtonGroup__button"
         disabled={false}
-        size="normal"
         type="button"
       >
         A button
@@ -98,7 +95,6 @@ exports[`<ButtonGroup> that renders a button should render default button correc
       <button
         className="Button Button--context_neutral ButtonGroup__button"
         disabled={false}
-        size="normal"
         type="button"
       >
         Another button

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -24,7 +24,7 @@ const Checkbox = forwardRef((props, ref) => {
                 id={id}
                 disabled={disabled}
             />
-            <label {...elem('label', props)} htmlFor={id} disabled={disabled}>
+            <label {...elem('label', props)} htmlFor={id}>
                 <span {...elem('box', props)}>
                     <svg
                         {...elem('svg', props)}

--- a/src/components/Checkbox/__tests__/Checkbox.spec.js
+++ b/src/components/Checkbox/__tests__/Checkbox.spec.js
@@ -24,7 +24,6 @@ describe('<Checkbox> that renders a checkbox', () => {
             </Checkbox>
         );
         expect(wrapper.find('input[disabled]')).toHaveLength(1);
-        expect(wrapper.find('label[disabled]')).toHaveLength(1);
         expect(wrapper.find('.Text--context_muted')).toHaveLength(1);
     });
 });

--- a/src/components/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
@@ -14,7 +14,6 @@ exports[`<Checkbox> that renders a checkbox should render default checkbox corre
     />
     <label
       className="Checkbox__label"
-      disabled={false}
       htmlFor="c1"
     >
       <span

--- a/src/components/Pagination/__tests__/__snapshots__/Pagination.spec.js.snap
+++ b/src/components/Pagination/__tests__/__snapshots__/Pagination.spec.js.snap
@@ -32,7 +32,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
         data-page={5}
         disabled={false}
         onClick={[Function]}
-        size="normal"
         type="button"
       >
         ‹ Previous
@@ -63,7 +62,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={1}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           1
@@ -100,7 +98,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={3}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           3
@@ -132,7 +129,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={4}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           4
@@ -164,7 +160,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={5}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           5
@@ -196,7 +191,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={6}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           6
@@ -228,7 +222,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={7}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           7
@@ -260,7 +253,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={8}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           8
@@ -292,7 +284,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={9}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           9
@@ -317,7 +308,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
         data-page={7}
         disabled={false}
         onClick={[Function]}
-        size="normal"
         type="button"
       >
         Next ›
@@ -366,7 +356,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={1}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           1
@@ -398,7 +387,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={2}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           2
@@ -430,7 +418,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={3}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           3
@@ -462,7 +449,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={4}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           4
@@ -494,7 +480,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={5}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           5
@@ -526,7 +511,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={6}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           6
@@ -558,7 +542,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={7}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           7
@@ -590,7 +573,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={8}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           8
@@ -622,7 +604,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={9}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           9
@@ -654,7 +635,6 @@ exports[`<Pagination> that renders a pagination component should render correctl
           data-page={10}
           disabled={false}
           onClick={[Function]}
-          size="normal"
           type="button"
         >
           10

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -25,7 +25,7 @@ const RadioButton = forwardRef((props, ref) => {
                 name={name}
                 disabled={disabled}
             />
-            <label {...elem('label', props)} htmlFor={id} disabled={disabled}>
+            <label {...elem('label', props)} htmlFor={id}>
                 <span {...elem('box', props)}>
                     <svg
                         {...elem('svg', props)}

--- a/src/components/RadioButton/__tests__/RadioButton.spec.js
+++ b/src/components/RadioButton/__tests__/RadioButton.spec.js
@@ -32,7 +32,6 @@ describe('<RadioButton> that renders a radio button', () => {
             </RadioButton>
         );
         expect(wrapper.find('input[disabled]')).toHaveLength(1);
-        expect(wrapper.find('label[disabled]')).toHaveLength(1);
         expect(wrapper.find('.Text--context_muted')).toHaveLength(1);
     });
 });

--- a/src/components/RadioButton/__tests__/__snapshots__/RadioButton.spec.js.snap
+++ b/src/components/RadioButton/__tests__/__snapshots__/RadioButton.spec.js.snap
@@ -16,7 +16,6 @@ exports[`<RadioButton> that renders a radio button should render default radio b
     />
     <label
       className="RadioButton__label"
-      disabled={false}
       htmlFor="c1"
     >
       <span
@@ -63,7 +62,6 @@ exports[`<RadioButton> that renders a radio button should render radio button wi
     />
     <label
       className="RadioButton__label"
-      disabled={false}
       htmlFor="c1"
     >
       <span


### PR DESCRIPTION
* Destruct props that should not be applied as attributes in rendered html
* Remove `disabled` attribute from Checkbox / RadioButton label as [it isn't valid html](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#Attributes)