### PR TITLE
fix(buttongroup): add separators, define context on group level, remove isInline prop

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -23,14 +23,11 @@
     padding: var(--spacing-2x) var(--spacing-4x);
     text-align: center;
     transition: all var(--transition-duration);
+    z-index: 1;
 
     &:focus,
-    &:hover {
-        box-shadow: 0 0 0 var(--outline-size) var(--transparent);
-    }
-    &:focus,
     &:active {
-        z-index: 1;
+        z-index: 100;
     }
 
     &[disabled] {

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -1,7 +1,8 @@
 @import '../../themes/oneui/oneui.scss';
 
 .Button {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     border: {
         radius: var(--border-radius);
         width: var(--line-normal);
@@ -23,7 +24,6 @@
     padding: var(--spacing-2x) var(--spacing-4x);
     text-align: center;
     transition: all var(--transition-duration);
-    z-index: 1;
 
     &:focus,
     &:active {

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -2,23 +2,34 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import bem from 'bem';
 import styles from './ButtonGroup.scss';
-import { SIZES } from '../../constants';
+import { CONTEXTS, SIZES } from '../../constants';
+
+const compact = obj =>
+    Object.keys(obj).reduce((accumulator, k) => {
+        if (obj[k] && typeof obj[k] !== typeof undefined) {
+            accumulator[k] = obj[k];
+        }
+        return accumulator;
+    }, {});
 
 const { block, elem } = bem({
     name: 'ButtonGroup',
     classnames: styles,
-    propsToMods: ['size', 'isBlock', 'isInline']
+    propsToMods: ['size', 'isBlock']
 });
 
 const ButtonGroup = props => {
-    const { children, size, isBlock, isInline, ...rest } = props;
+    const { children, context, size, isBlock, ...rest } = props;
 
     return (
         <div {...rest} {...block(props)} role="group">
             {React.Children.map(children, button =>
                 React.cloneElement(button, {
-                    ...button.props,
-                    size,
+                    ...compact({
+                        ...button.props,
+                        context,
+                        size
+                    }),
                     ...elem('button', props)
                 })
             )}
@@ -31,18 +42,18 @@ ButtonGroup.displayName = 'ButtonGroup';
 ButtonGroup.propTypes = {
     /** The buttons in this group */
     children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+    /** The context for all buttons in this group (e.g. brand, primary, bad, good etc.) */
+    context: PropTypes.oneOf([...CONTEXTS, 'link']),
     /** Whether or not to show block-level button group (full width) */
     isBlock: PropTypes.bool,
-    /** Whether or not to show button group as inline element */
-    isInline: PropTypes.bool,
     /** The size of the buttons in the button group */
     size: PropTypes.oneOf(SIZES)
 };
 
 ButtonGroup.defaultProps = {
+    context: null,
     size: 'normal',
-    isBlock: false,
-    isInline: false
+    isBlock: false
 };
 
 export default ButtonGroup;

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -4,14 +4,6 @@ import bem from 'bem';
 import styles from './ButtonGroup.scss';
 import { CONTEXTS, SIZES } from '../../constants';
 
-const compact = obj =>
-    Object.keys(obj).reduce((accumulator, k) => {
-        if (obj[k] && typeof obj[k] !== typeof undefined) {
-            accumulator[k] = obj[k];
-        }
-        return accumulator;
-    }, {});
-
 const { block, elem } = bem({
     name: 'ButtonGroup',
     classnames: styles,
@@ -25,11 +17,9 @@ const ButtonGroup = props => {
         <div {...rest} {...block(props)} role="group">
             {React.Children.map(children, button =>
                 React.cloneElement(button, {
-                    ...compact({
-                        ...button.props,
-                        context,
-                        size
-                    }),
+                    ...button.props,
+                    context,
+                    size,
                     ...elem('button', props)
                 })
             )}
@@ -51,7 +41,7 @@ ButtonGroup.propTypes = {
 };
 
 ButtonGroup.defaultProps = {
-    context: null,
+    context: 'neutral',
     size: 'normal',
     isBlock: false
 };

--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -18,12 +18,6 @@
         + .ButtonGroup__button {
             margin-left: -1px;
         }
-        // &:not(:first-child):not(:focus) {
-        //     border-left-color: transparent;
-        // }
-        // &:not(:last-child):not(:focus) {
-        //     border-right-color: transparent;
-        // }
     }
 
     .Button--context {

--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -21,7 +21,7 @@
     }
 
     .Button--context {
-        @each $context in (brand, primary, accent, info, good, warning, bad) {
+        @each $context in ($contexts) {
             &_#{$context} {
                 &:not(:first-child):not(:focus) {
                     border-left-color: var(--color-#{$context}-25);

--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -1,7 +1,7 @@
 @import '../../themes/oneui/oneui.scss';
 
 .ButtonGroup {
-    display: flex;
+    display: inline-flex;
 
     &__button {
         border-radius: 0;
@@ -18,14 +18,30 @@
         + .ButtonGroup__button {
             margin-left: -1px;
         }
+        // &:not(:first-child):not(:focus) {
+        //     border-left-color: transparent;
+        // }
+        // &:not(:last-child):not(:focus) {
+        //     border-right-color: transparent;
+        // }
+    }
+
+    .Button--context {
+        @each $context in (brand, primary, accent, info, good, warning, bad) {
+            &_#{$context} {
+                &:not(:first-child):not(:focus) {
+                    border-left-color: var(--color-#{$context}-25);
+                }
+                &:not(:last-child):not(:focus) {
+                    border-right-color: var(--color-#{$context}-25);
+                }
+            }
+        }
     }
 
     &--isBlock {
+        display: flex;
         width: 100%;
-    }
-
-    &--isInline {
-        display: inline-flex;
     }
 
     &__button--isBlock {

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -2,8 +2,8 @@
 
 exports[`<ButtonGroup> that renders a button should add classes when props are changed 1`] = `
 <ButtonGroup
+  context={null}
   isBlock={true}
-  isInline={false}
   size="large"
 >
   <div
@@ -56,8 +56,8 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
 
 exports[`<ButtonGroup> that renders a button should render default button correctly 1`] = `
 <ButtonGroup
+  context={null}
   isBlock={false}
-  isInline={false}
   size="normal"
 >
   <div

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<ButtonGroup> that renders a button should add classes when props are changed 1`] = `
 <ButtonGroup
-  context={null}
+  context="neutral"
   isBlock={true}
   size="large"
 >
@@ -56,7 +56,7 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
 
 exports[`<ButtonGroup> that renders a button should render default button correctly 1`] = `
 <ButtonGroup
-  context={null}
+  context="neutral"
   isBlock={false}
   size="normal"
 >

--- a/stories/ButtonGroup.js
+++ b/stories/ButtonGroup.js
@@ -2,18 +2,25 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 import { Button, ButtonGroup } from '@textkernel/oneui';
-import { SIZES } from '@textkernel/oneui/constants';
+import { CONTEXTS, SIZES } from '@textkernel/oneui/constants';
 
 storiesOf('ButtonGroup', module)
     .addDecorator(withKnobs)
     .add('ButtonGroup', () => (
         <ButtonGroup
+            context={select('Context', [...CONTEXTS, 'link'], CONTEXTS[0])}
             isBlock={boolean('isBlock', false)}
-            isInline={boolean('isInline', false)}
             size={select('Size', SIZES, SIZES[1])}
         >
-            <Button context="neutral">Some</Button>
-            <Button context="neutral">Button</Button>
-            <Button context="neutral">Group</Button>
+            <Button
+                href="#"
+                onClick={e => {
+                    e.preventDefault();
+                }}
+            >
+                Some
+            </Button>
+            <Button>Button</Button>
+            <Button>Group</Button>
         </ButtonGroup>
     ));


### PR DESCRIPTION
* Add separators in between buttons
* Define `context` on button group level, applies to all buttons in the group
* Deprecate `isInline` prop: ButtonGroup is inline element by default, can be toggled to `isBlock` through prop

BREAKING CHANGE: ButtonGroup isInline prop is deprecated