### PR TITLE
chore(jest): ignore packages/bem in codecov report

### DIFF
--- a/etc/test/jest.config.js
+++ b/etc/test/jest.config.js
@@ -34,5 +34,5 @@ module.exports = {
 
     // An array of regexp pattern strings that are matched against all file paths before executing
     // the test. If the file path matches any of the patterns, coverage information will be skipped.
-    coveragePathIgnorePatterns: ['/dummy-components/', '/node_modules/']
+    coveragePathIgnorePatterns: ['/dummy-components/', '/node_modules/', '/packages/bem/']
 };


### PR DESCRIPTION
Do not include `packages/bem/` in code coverage reporting. Tests are still executed but since it is to be split off to a separate package it's not very relevant to be included in coverage report. Codecov report gives a more relevant and accurate indication of test coverage for actual OneUI components.