### PR TITLE
test: extend tests for uncovered lines

### DIFF
--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -52,7 +52,7 @@ const Pagination = props => {
 
     const handleClick = e => {
         const {
-            dataset: { page = null }
+            dataset: { page }
         } = e.target;
         const pageNum = +page;
 

--- a/src/components/Tabs/__tests__/Tabs.spec.js
+++ b/src/components/Tabs/__tests__/Tabs.spec.js
@@ -4,7 +4,9 @@ import Tabs from '../Tabs';
 import Tab from '../Tab';
 
 describe('<Tabs> that renders tab container with some tabs', () => {
-    it('should render simple tabs', () => {
+    it('should render simple tabs (without onChange callback prop)', () => {
+        const onChange = jest.fn();
+
         const wrapper = mount(
             <Tabs activeTabId="1">
                 <Tab id="1" label="First">
@@ -16,6 +18,14 @@ describe('<Tabs> that renders tab container with some tabs', () => {
             </Tabs>
         );
         expect(toJson(wrapper)).toMatchSnapshot();
+
+        wrapper
+            .find('TabMenu')
+            .find('TabItem')
+            .at(1)
+            .simulate('click');
+
+        expect(onChange).not.toHaveBeenCalled();
     });
 
     it('should switch tabs correctly', () => {

--- a/src/components/Tabs/__tests__/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__tests__/__snapshots__/Tabs.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tabs> that renders tab container with some tabs should render simple tabs 1`] = `
+exports[`<Tabs> that renders tab container with some tabs should render simple tabs (without onChange callback prop) 1`] = `
 <Tabs
   activeTabId="1"
   gutters={false}

--- a/src/utils/OneUI/OneUI.js
+++ b/src/utils/OneUI/OneUI.js
@@ -16,7 +16,7 @@ class OneUI {
      * @param {number} themeConfig.maxTime - Max time to wait for the theme to be loaded
      * @param {Object} themeConfig.ponyfillOptions - Set of options that can be used to configure the ponyfill. Options: https://www.npmjs.com/package/css-vars-ponyfill#options
      */
-    static init({ themeURL = '', maxTime = DEFAULT_LOADING_TIMEOUT, ponyfillOptions } = {}) {
+    static init({ themeURL = '', maxTime = DEFAULT_LOADING_TIMEOUT, ponyfillOptions }) {
         const loadTheme = Promise.all([
             OneUI.applyTheme(themeURL),
             OneUI.startCssVarsPonyfill(ponyfillOptions)

--- a/src/utils/OneUI/__tests__/OneUI.spec.js
+++ b/src/utils/OneUI/__tests__/OneUI.spec.js
@@ -111,4 +111,11 @@ describe('OneUI loader that starts the ponyfill and attach the theme to DOM', ()
             expect(ponyfillOptions.onError).toBeCalledTimes(1);
         });
     });
+
+    it('should throw an error when timeout expired', () =>
+        expect(
+            OneUI.init({
+                maxTime: 1
+            })
+        ).rejects.toThrowErrorMatchingSnapshot());
 });

--- a/src/utils/OneUI/__tests__/__snapshots__/OneUI.spec.js.snap
+++ b/src/utils/OneUI/__tests__/__snapshots__/OneUI.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OneUI loader that starts the ponyfill and attach the theme to DOM should throw an error when timeout expired 1`] = `"Theme \\"\\" not loaded. Loading time expired"`;


### PR DESCRIPTION
* Remove default `null` value from destructuring assignment in Pagination component that would never occur and cannot be tested
* Extend tests for Tabs component when used without `onChange` callback prop
* Extend tests for OneUI util: check that error is thrown when timeout exceeded