### PR TITLE
docs: extend documentation about releasing and commit message format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ OneUI's [release procedure](RELEASING.md) and [changelog](CHANGELOG.md) automati
 [optional footer]
 ```
 
-Commit types include:
+Commit types (required) include:
 * `feat`: A new feature (equivalent to `MINOR`)
 * `fix`: A bug fix (equivalent to `PATCH`)
 * `docs`: Changes to documentation
@@ -105,10 +105,11 @@ Commit types include:
 * `style`: Code style change (indentation, semicolons, ...)
 * `perf`: Performance enhancements
 * `refactor`: Code refactoring without changes to public API
+* `build`: Changes that affect the build system or external dependencies
 
 Use imperative, present tense in your commit description ("change", not "changed" or "changes") without uppercases or period (.) at the end.
 
-**Breaking changes** should be explicitly marked (with uppercase) in the message footer, e.g. `BREAKING CHANGE: <note>`. This will result in a new `MAJOR` package version.
+**Breaking changes** should be explicitly marked (singular, with uppercase) in the message footer, e.g. `BREAKING CHANGE: <note>`. This will result in a new `MAJOR` package version.
 
 ### Merging
 When merging a branch, squash its commits for the changelog to be nice and tidy. Each pull request / squashed commit should eventually equal one fix / feature / change in docs or tests.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,18 @@ Version numbers should not be prefixed (e.g. 1.2.3, **not** v1.2.3).
 
 ## Release Procedure
 
-To make a new release, simply run **`npm run release`**.
+**First**, make sure your master branch is up to date and do a dry-run to verify that the expected version number will be used:
+
+```bash
+(master)$ git pull
+(master)$ npm run release -- --dry-run
+```
+
+**Finally**, simply run the following to make a new release:
+
+```bash
+(master)$ npm run release
+```
 
 The release script will...
 1. ...auto determine a new version number on the basis of commit messages since last tag.


### PR DESCRIPTION
* Add note about doing a dry run first when releasing
* Make it more clear how to indicate breaking changes in commit message
* Add type `build` to commit message format docs