### PR TITLE
feat: renamed OneUI.startCssVarsPonyfill to OneUI.applyCssVarsPonyfill()

### DIFF
--- a/src/utils/OneUI/OneUI.js
+++ b/src/utils/OneUI/OneUI.js
@@ -19,7 +19,7 @@ class OneUI {
     static init({ themeURL = '', maxTime = DEFAULT_LOADING_TIMEOUT, ponyfillOptions } = {}) {
         const loadTheme = Promise.all([
             OneUI.applyTheme(themeURL),
-            OneUI.startCssVarsPonyfill(ponyfillOptions)
+            OneUI.applyCssVarsPonyfill(ponyfillOptions)
         ]);
 
         const timeout = new Promise((resolve, reject) =>
@@ -36,7 +36,7 @@ class OneUI {
      * Loads the CSS Vars ponyfill in case the browser is Internet Explorer 11. It can also
      * forces to load in modern browsers in case the user passes `onlyLegacy` property as false
      */
-    static startCssVarsPonyfill(ponyfillOptions = {}) {
+    static applyCssVarsPonyfill(ponyfillOptions = {}) {
         return new Promise((resolve, reject) => {
             const shouldForcePonyfill = ponyfillOptions.onlyLegacy === false;
 

--- a/src/utils/OneUI/__tests__/OneUI.spec.js
+++ b/src/utils/OneUI/__tests__/OneUI.spec.js
@@ -21,7 +21,7 @@ describe('OneUI loader that starts the ponyfill and attach the theme to DOM', ()
             configurable: true
         });
 
-        OneUI.startCssVarsPonyfill();
+        OneUI.applyCssVarsPonyfill();
 
         expect(cssVarsPonyfill).toBeCalledTimes(1);
     });
@@ -35,7 +35,7 @@ describe('OneUI loader that starts the ponyfill and attach the theme to DOM', ()
             configurable: true
         });
 
-        OneUI.startCssVarsPonyfill();
+        OneUI.applyCssVarsPonyfill();
 
         expect(cssVarsPonyfill).toBeCalledTimes(0);
     });
@@ -45,18 +45,18 @@ describe('OneUI loader that starts the ponyfill and attach the theme to DOM', ()
         const ponyfillOptions = { onlyLegacy: false };
 
         const mockedApplyTheme = jest.spyOn(OneUI, 'applyTheme');
-        const mockedStartCssVarsPonyfill = jest.spyOn(OneUI, 'startCssVarsPonyfill');
+        const mockedApplyCssVarsPonyfill = jest.spyOn(OneUI, 'applyCssVarsPonyfill');
 
         mockedApplyTheme.mockImplementation(() => Promise.resolve());
-        mockedStartCssVarsPonyfill.mockImplementation(() => Promise.resolve());
+        mockedApplyCssVarsPonyfill.mockImplementation(() => Promise.resolve());
 
         OneUI.init({ themeURL, ponyfillOptions });
 
         expect(mockedApplyTheme).toBeCalledWith(themeURL);
-        expect(mockedStartCssVarsPonyfill).toBeCalledWith(ponyfillOptions);
+        expect(mockedApplyCssVarsPonyfill).toBeCalledWith(ponyfillOptions);
 
         mockedApplyTheme.mockRestore();
-        mockedStartCssVarsPonyfill.mockRestore();
+        mockedApplyCssVarsPonyfill.mockRestore();
     });
 
     it('should not attach link element in the DOM when themeURL is not provided', () => {
@@ -86,7 +86,7 @@ describe('OneUI loader that starts the ponyfill and attach the theme to DOM', ()
             onComplete: jest.fn()
         };
 
-        return OneUI.startCssVarsPonyfill(ponyfillOptions).then(() => {
+        return OneUI.applyCssVarsPonyfill(ponyfillOptions).then(() => {
             expect(ponyfillOptions.onComplete).toBeCalledTimes(1);
         });
     });
@@ -107,7 +107,7 @@ describe('OneUI loader that starts the ponyfill and attach the theme to DOM', ()
             onError: jest.fn()
         };
 
-        return OneUI.startCssVarsPonyfill(ponyfillOptions).catch(() => {
+        return OneUI.applyCssVarsPonyfill(ponyfillOptions).catch(() => {
             expect(ponyfillOptions.onError).toBeCalledTimes(1);
         });
     });


### PR DESCRIPTION
Initial idea was to call OneUI.init() once on page load (that used to call
OneUI.startCssVarsPonyfill underthegood). But with code splitting
`cssVarsPonyfill` should be appled after any route navigation.
So it should be exposed with a more meaningfull name.

BREAKING CHANGE: if you used `OneUI.startCssVarsPonyfill()` directly in your app
rename it to `OneUI.applyCssVarsPonyfill()`.