### PR TITLE
fix(LocationSelector): rename components and fix unit tests

### DIFF
--- a/src/components/LocationSelector/LocationSelector.js
+++ b/src/components/LocationSelector/LocationSelector.js
@@ -1,21 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import bem from 'bem';
-import { LoadScriptNext } from '@react-google-maps/api';
 import { FaMapMarkerAlt } from 'react-icons/fa';
-import { Text, Modal, FieldWrapper, LoadingSpinner, LocationSelector } from '../../../index';
-import { findCenter, getRadiusInMeters } from '../utils';
-import styles from './LocationSelectorWithGoogleLoader.scss';
-
-const GOOGLE_API_LIBRARIES = ['places'];
+import { Text, Modal, FieldWrapper } from '../../index';
+import LocationSelectorDialogWithGoogleLoader from './LocationSelectorDialogWithGoogleLoader';
+import { findCenter, getRadiusInMeters } from './utils';
+import styles from './LocationSelector.scss';
 
 const { block, elem } = bem({
-    name: 'LocationSelectorWithGoogleLoader',
+    name: 'LocationSelector',
     classnames: styles,
     propsToMods: ['muted'],
 });
 
-function LocationSelectorWithGoogleLoader(props) {
+function LocationSelector(props) {
     const {
         /** Google props */
         apiKey,
@@ -134,42 +132,37 @@ function LocationSelectorWithGoogleLoader(props) {
                 onRequestClose={handleCloseModal}
                 contentLabel={modalContentLabel}
             >
-                <LoadScriptNext
-                    googleMapsApiKey={apiKey}
+                <LocationSelectorDialogWithGoogleLoader
+                    apiKey={apiKey}
                     language={language}
                     region={region}
-                    loadingElement={<LoadingSpinner centerIn="parent" />}
-                    libraries={GOOGLE_API_LIBRARIES}
                     {...additionalGoogleProps}
-                >
-                    <LocationSelector
-                        inputPlaceholder={inputPlaceholder}
-                        minRadius={minRadius}
-                        maxRadius={maxRadius}
-                        radiusStep={radiusStep}
-                        renderRadiusLabel={renderRadiusLabel}
-                        onRemoveLocation={onRemoveLocation}
-                        doneLabel={doneLabel}
-                        country={country}
-                        placeTypes={placeTypes}
-                        noSuggestionsPlaceholder={noSuggestionsPlaceholder}
-                        showCountryInSuggestions={showCountryInSuggestions}
-                        onLocationAutocompleteError={onLocationAutocompleteError}
-                        onUpdateLocation={onUpdateLocation}
-                        selectedLocations={selectedLocations}
-                        getMarkers={getMarkers}
-                        onAddLocation={handleAddLocation}
-                        onCloseModal={handleCloseModal}
-                    />
-                </LoadScriptNext>
+                    inputPlaceholder={inputPlaceholder}
+                    minRadius={minRadius}
+                    maxRadius={maxRadius}
+                    radiusStep={radiusStep}
+                    renderRadiusLabel={renderRadiusLabel}
+                    onRemoveLocation={onRemoveLocation}
+                    doneLabel={doneLabel}
+                    country={country}
+                    placeTypes={placeTypes}
+                    noSuggestionsPlaceholder={noSuggestionsPlaceholder}
+                    showCountryInSuggestions={showCountryInSuggestions}
+                    onLocationAutocompleteError={onLocationAutocompleteError}
+                    onUpdateLocation={onUpdateLocation}
+                    selectedLocations={selectedLocations}
+                    getMarkers={getMarkers}
+                    onAddLocation={handleAddLocation}
+                    onCloseModal={handleCloseModal}
+                />
             </Modal>
         </div>
     );
 }
 
-LocationSelectorWithGoogleLoader.displayName = 'LocationSelectorWithGoogleLoader';
+LocationSelector.displayName = 'LocationSelector';
 
-LocationSelectorWithGoogleLoader.propTypes = {
+LocationSelector.propTypes = {
     /** Google api key */
     apiKey: PropTypes.string.isRequired,
     /** language in which suggestions should be displayed */
@@ -239,7 +232,7 @@ LocationSelectorWithGoogleLoader.propTypes = {
     onBlur: PropTypes.func,
 };
 
-LocationSelectorWithGoogleLoader.defaultProps = {
+LocationSelector.defaultProps = {
     radiusDefaultValue: 1,
     minRadius: 1,
     maxRadius: 100,
@@ -253,4 +246,4 @@ LocationSelectorWithGoogleLoader.defaultProps = {
     onLocationAutocompleteError: () => null,
 };
 
-export default LocationSelectorWithGoogleLoader;
+export default LocationSelector;

--- a/src/components/LocationSelector/LocationSelector.js
+++ b/src/components/LocationSelector/LocationSelector.js
@@ -81,13 +81,13 @@ function LocationSelector(props) {
         const { Geocoder } = window.google.maps;
         const geocoder = new Geocoder();
 
-        findCenter(geocoder, location.place_id)
+        return findCenter(geocoder, location.place_id)
             .then(center => {
                 const locationToAdd = {
                     ...location,
                     center: {
-                        lng: center.lng(),
-                        lat: center.lat(),
+                        lng: typeof center.lng === 'function' ? center.lng() : center.lng,
+                        lat: typeof center.lat === 'function' ? center.lat() : center.lat,
                     },
                     radius: radiusDefaultValue,
                 };

--- a/src/components/LocationSelector/LocationSelector.scss
+++ b/src/components/LocationSelector/LocationSelector.scss
@@ -5,7 +5,7 @@ $modal-min-width: 2 * $location-card-width;
 $modal-min-height: 400px;
 $icon-margin-adjustment: 5px 1px -3px 3px;
 
-.LocationSelectorWithGoogleLoader {
+.LocationSelector {
     &__mainTextInputWrapper {
         box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.1);
         height: $text-input-height;

--- a/src/components/LocationSelector/LocationSelectorDialog/LocationSelectorDialog.js
+++ b/src/components/LocationSelector/LocationSelectorDialog/LocationSelectorDialog.js
@@ -114,13 +114,13 @@ LocationSelectorDialog.propTypes = {
      */
     placeTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
     /** show country name in autocomplete suggestions */
-    showCountryInSuggestions: PropTypes.bool.isRequired,
+    showCountryInSuggestions: PropTypes.bool,
     /** placeholder for both main field and autocomplete field in modal */
     inputPlaceholder: PropTypes.string.isRequired,
     /** placeholder for empty LocationAutocomplete list */
     noSuggestionsPlaceholder: PropTypes.string.isRequired,
     /** function to be executed if error occurs while fetching suggestions */
-    onLocationAutocompleteError: PropTypes.func.isRequired,
+    onLocationAutocompleteError: PropTypes.func,
     /** label for the Done button */
     doneLabel: PropTypes.string.isRequired,
     /** function called with location object as an argument when it is selected from the suggestions */
@@ -131,6 +131,11 @@ LocationSelectorDialog.propTypes = {
     onRemoveLocation: PropTypes.func.isRequired,
     /** function to calculate marker positions in Map  */
     getMarkers: PropTypes.func.isRequired,
+};
+
+LocationSelectorDialog.defaultProps = {
+    showCountryInSuggestions: false,
+    onLocationAutocompleteError: null,
 };
 
 export default LocationSelectorDialog;

--- a/src/components/LocationSelector/LocationSelectorDialog/LocationSelectorDialog.js
+++ b/src/components/LocationSelector/LocationSelectorDialog/LocationSelectorDialog.js
@@ -2,14 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import bem from 'bem';
 import { Map, Button, LocationCard, LocationAutocomplete } from '../../../index';
-import styles from './LocationSelector.scss';
+import styles from './LocationSelectorDialog.scss';
 
 const { elem } = bem({
-    name: 'LocationSelector',
+    name: 'LocationSelectorDialog',
     classnames: styles,
 });
 
-const LocationSelector = props => {
+const LocationSelectorDialog = props => {
     const {
         /** FieldWrapper props */
         inputPlaceholder,
@@ -83,9 +83,9 @@ const LocationSelector = props => {
     );
 };
 
-LocationSelector.displayName = 'LocationSelector';
+LocationSelectorDialog.displayName = 'LocationSelectorDialog';
 
-LocationSelector.propTypes = {
+LocationSelectorDialog.propTypes = {
     /** stores an array of selected location objects */
     selectedLocations: PropTypes.arrayOf(
         PropTypes.shape({
@@ -129,7 +129,8 @@ LocationSelector.propTypes = {
     onUpdateLocation: PropTypes.func.isRequired,
     /** function with a locationId as an argument to be removed */
     onRemoveLocation: PropTypes.func.isRequired,
+    /** function to calculate marker positions in Map  */
     getMarkers: PropTypes.func.isRequired,
 };
 
-export default LocationSelector;
+export default LocationSelectorDialog;

--- a/src/components/LocationSelector/LocationSelectorDialog/LocationSelectorDialog.scss
+++ b/src/components/LocationSelector/LocationSelectorDialog/LocationSelectorDialog.scss
@@ -1,7 +1,7 @@
 $input-line-height: 67px;
 $location-card-width: 300px;
 
-.LocationSelector {
+.LocationSelectorDialog {
     &__inputLine {
         display: flex;
         box-sizing: border-box;

--- a/src/components/LocationSelector/LocationSelectorDialog/__tests__/LocationSelectorDialog.spec.js
+++ b/src/components/LocationSelector/LocationSelectorDialog/__tests__/LocationSelectorDialog.spec.js
@@ -1,0 +1,137 @@
+import React from 'react';
+import toJson from 'enzyme-to-json';
+import { act } from 'react-dom/test-utils';
+import stabGoogleApi, { getPlacePredictionsMock } from '../../../../__mocks__/googleApiMock';
+import predictionsMock from '../../../LocationAutocomplete/__mocks__/predictions.json';
+import LocationSelectorDialog from '../LocationSelectorDialog';
+
+stabGoogleApi();
+
+describe('LocationSelectorDialog component', () => {
+    const selectedLocations = [
+        {
+            id: 'ajdo-219a-j19v-0491',
+            description: 'Amsterdam',
+            center: {
+                lng: 4.894539799999961,
+                lat: 52.3666969,
+            },
+            radius: 42,
+            sliderLabel: '42km',
+        },
+        {
+            id: 'ajdo-219a-j19v-0492',
+            description: 'Utrecht',
+            center: {
+                lng: 5.121420100000023,
+                lat: 52.09073739999999,
+            },
+            radius: 20,
+            sliderLabel: '20km',
+        },
+    ];
+
+    const minRadius = 1;
+    const maxRadius = 100;
+    const radiusStep = 1;
+    const renderRadiusLabel = r => `+ ${r} km`;
+    const country = 'NL';
+    const placeTypes = ['(regions)'];
+
+    const inputPlaceholder = 'inputPlaceholder';
+    const noSuggestionsPlaceholder = 'noSuggestionsPlaceholder';
+    const doneLabel = 'doneLabel';
+
+    const onAddLocationMock = jest.fn();
+    const onUpdateLocationMock = jest.fn();
+    const onRemoveLocationMock = jest.fn();
+    const onLocationAutocompleteErrorMock = jest.fn();
+    const onCloseModal = jest.fn();
+
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = mount(
+            <LocationSelectorDialog
+                inputPlaceholder={inputPlaceholder}
+                minRadius={minRadius}
+                maxRadius={maxRadius}
+                radiusStep={radiusStep}
+                renderRadiusLabel={renderRadiusLabel}
+                onRemoveLocation={onRemoveLocationMock}
+                doneLabel={doneLabel}
+                country={country}
+                placeTypes={placeTypes}
+                noSuggestionsPlaceholder={noSuggestionsPlaceholder}
+                showCountryInSuggestions
+                onLocationAutocompleteError={onLocationAutocompleteErrorMock}
+                onUpdateLocation={onUpdateLocationMock}
+                selectedLocations={selectedLocations}
+                getMarkers={() => []}
+                onAddLocation={onAddLocationMock}
+                onCloseModal={onCloseModal}
+            />
+        );
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should render correctly', () => {
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+    it('should close LocationSelectorDialog by pressing on Done button', () => {
+        wrapper.find('.Button').simulate('click');
+        expect(onCloseModal).toHaveBeenCalledTimes(1);
+    });
+    it('should call onAddLocation by selecting an item from the autosuggestion list', () => {
+        jest.useFakeTimers();
+        getPlacePredictionsMock.mockImplementationOnce((req, cb) => cb(predictionsMock, 'OK'));
+        wrapper.find('input').simulate('change', { target: { value: 'Tonga' } });
+        act(() => {
+            jest.runAllTimers();
+        });
+        wrapper.find('input').simulate('click');
+
+        expect(wrapper.find('Autosuggest').find('li')).toHaveLength(5);
+        expect(onAddLocationMock).not.toHaveBeenCalled();
+
+        wrapper
+            .find('Autosuggest')
+            .find('li')
+            .at(0)
+            .childAt(0)
+            .simulate('click');
+
+        expect(onAddLocationMock).toHaveBeenCalledTimes(1);
+    });
+    it('should call onRemoveLocation by clicking on Close button of the selected location item', () => {
+        expect(onRemoveLocationMock).not.toHaveBeenCalled();
+
+        wrapper
+            .find('ul')
+            .at(1)
+            .childAt(0)
+            .find('button')
+            .simulate('click');
+
+        expect(onRemoveLocationMock).toHaveBeenCalledTimes(1);
+    });
+    // TODO: Update test so slider handle would be reachable in order to update a LocationCard
+    it.skip('should call onUpdateLocation by setting a new location radius valueof the selected location item', () => {
+        expect(onUpdateLocationMock).not.toHaveBeenCalled();
+
+        wrapper
+            .find('ul')
+            .at(1)
+            .childAt(0)
+            .find('div.rc-slider-handle')
+            .simulate('mouseover')
+            .simulate('mousedown')
+            .simulate('mousemove')
+            .simulate('mouseup');
+
+        expect(onUpdateLocationMock).toHaveBeenCalled();
+    });
+});

--- a/src/components/LocationSelector/LocationSelectorDialog/__tests__/__snapshots__/LocationSelectorDialog.spec.js.snap
+++ b/src/components/LocationSelector/LocationSelectorDialog/__tests__/__snapshots__/LocationSelectorDialog.spec.js.snap
@@ -1,0 +1,680 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LocationSelectorDialog component should render correctly 1`] = `
+<LocationSelectorDialog
+  country="NL"
+  doneLabel="doneLabel"
+  getMarkers={[Function]}
+  inputPlaceholder="inputPlaceholder"
+  maxRadius={100}
+  minRadius={1}
+  noSuggestionsPlaceholder="noSuggestionsPlaceholder"
+  onAddLocation={[MockFunction]}
+  onCloseModal={[MockFunction]}
+  onLocationAutocompleteError={[MockFunction]}
+  onRemoveLocation={[MockFunction]}
+  onUpdateLocation={[MockFunction]}
+  placeTypes={
+    Array [
+      "(regions)",
+    ]
+  }
+  radiusStep={1}
+  renderRadiusLabel={[Function]}
+  selectedLocations={
+    Array [
+      Object {
+        "center": Object {
+          "lat": 52.3666969,
+          "lng": 4.894539799999961,
+        },
+        "description": "Amsterdam",
+        "id": "ajdo-219a-j19v-0491",
+        "radius": 42,
+        "sliderLabel": "42km",
+      },
+      Object {
+        "center": Object {
+          "lat": 52.09073739999999,
+          "lng": 5.121420100000023,
+        },
+        "description": "Utrecht",
+        "id": "ajdo-219a-j19v-0492",
+        "radius": 20,
+        "sliderLabel": "20km",
+      },
+    ]
+  }
+  showCountryInSuggestions={true}
+>
+  <div
+    className="LocationSelectorDialog__inputLine"
+  >
+    <LocationAutocomplete
+      className="LocationSelectorDialog__searchField"
+      country="NL"
+      hidePoweredByGoogleLogo={true}
+      inputPlaceholder="inputPlaceholder"
+      isFocused={true}
+      noSuggestionsPlaceholder="noSuggestionsPlaceholder"
+      onError={[MockFunction]}
+      onSelectionChange={[MockFunction]}
+      placeTypes={
+        Array [
+          "(regions)",
+        ]
+      }
+      showCountryInSuggestions={true}
+    >
+      <Autosuggest
+        className="LocationSelectorDialog__searchField"
+        clearTitle=""
+        getSuggestions={null}
+        iconNode={
+          <FaMapMarkerAlt
+            className="LocationAutocomplete__icon"
+          />
+        }
+        inputPlaceholder="inputPlaceholder"
+        isFocused={true}
+        isLoading={false}
+        isMultiselect={false}
+        isProminent={false}
+        listRenderer={[Function]}
+        noSuggestionsPlaceholder="noSuggestionsPlaceholder"
+        onBlur={[Function]}
+        onClearAllSelected={null}
+        onInputValueChange={[Function]}
+        onSelectionChange={[Function]}
+        selectedPlaceholder=""
+        selectedSuggestions={null}
+        showClearButton={false}
+        suggestionToString={[Function]}
+      >
+        <div
+          className="Autosuggest LocationSelectorDialog__searchField"
+        >
+          <Downshift
+            defaultHighlightedIndex={0}
+            defaultIsOpen={false}
+            environment={[Window]}
+            getA11yStatusMessage={[Function]}
+            inputValue=""
+            itemToString={[Function]}
+            onChange={[Function]}
+            onInputValueChange={[Function]}
+            onOuterClick={[Function]}
+            onSelect={[Function]}
+            onStateChange={[Function]}
+            onUserAction={[Function]}
+            scrollIntoView={[Function]}
+            selectedItemChanged={[Function]}
+            stateReducer={[Function]}
+            suppressRefError={false}
+          >
+            <div
+              aria-expanded={false}
+              aria-haspopup="listbox"
+              aria-labelledby="downshift-0-label"
+              aria-owns={null}
+              className="Autosuggest__main Autosuggest__main--focused"
+              role="combobox"
+            >
+              <FieldWrapper
+                className="Autosuggest__field"
+                clearLabel=""
+                isFocused={true}
+                onClear={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                showClearButton={false}
+              >
+                <div
+                  className="FieldWrapper FieldWrapper--isFocused Autosuggest__field"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    className="FieldWrapper__content"
+                  >
+                    <div
+                      className="Autosuggest__wrapper Autosuggest__wrapper--focused"
+                      role="searchbox"
+                      tabIndex="0"
+                    >
+                      <FaMapMarkerAlt
+                        className="Autosuggest__spacedElem LocationAutocomplete__icon"
+                      >
+                        <IconBase
+                          attr={
+                            Object {
+                              "viewBox": "0 0 384 512",
+                            }
+                          }
+                          className="Autosuggest__spacedElem LocationAutocomplete__icon"
+                        >
+                          <svg
+                            className="Autosuggest__spacedElem LocationAutocomplete__icon"
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 384 512"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
+                              key="0"
+                            />
+                          </svg>
+                        </IconBase>
+                      </FaMapMarkerAlt>
+                      <input
+                        aria-activedescendant={null}
+                        aria-autocomplete="list"
+                        aria-controls={null}
+                        aria-labelledby="downshift-0-label"
+                        autoComplete="off"
+                        className="Autosuggest__input"
+                        id="downshift-0-input"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onKeyDown={[Function]}
+                        placeholder="inputPlaceholder"
+                        value=""
+                      />
+                    </div>
+                    <List
+                      aria-labelledby="downshift-0-label"
+                      className="Autosuggest__list--focused"
+                      doSelectOnNavigate={false}
+                      id="downshift-0-menu"
+                      isControlledNavigation={true}
+                      isDivided={false}
+                      role="listbox"
+                    >
+                      <ul
+                        aria-labelledby="downshift-0-label"
+                        className="List Autosuggest__list--focused"
+                        id="downshift-0-menu"
+                        role="listbox"
+                      />
+                    </List>
+                  </div>
+                </div>
+              </FieldWrapper>
+            </div>
+          </Downshift>
+        </div>
+      </Autosuggest>
+    </LocationAutocomplete>
+    <Button
+      className="LocationSelectorDialog__button"
+      context="brand"
+      disabled={false}
+      href={null}
+      isBlock={false}
+      isInline={false}
+      onClick={[MockFunction]}
+      size="normal"
+      type="button"
+    >
+      <button
+        className="Button Button--context_brand LocationSelectorDialog__button"
+        disabled={false}
+        onClick={[MockFunction]}
+        type="button"
+      >
+        doneLabel
+      </button>
+    </Button>
+  </div>
+  <div
+    className="LocationSelectorDialog__locationsWrapper"
+  >
+    <ul
+      className="LocationSelectorDialog__locationCardsContainer"
+    >
+      <LocationCard
+        As="li"
+        className="LocationSelectorDialog__locationCard"
+        distanceRadius={42}
+        key="ajdo-219a-j19v-0491"
+        locationId="ajdo-219a-j19v-0491"
+        locationTitle="Amsterdam"
+        maxRadius={100}
+        minRadius={1}
+        onDelete={[MockFunction]}
+        onRadiusChange={[MockFunction]}
+        radiusStep={1}
+        sliderLabel="+ 42 km"
+      >
+        <li
+          className="LocationCard LocationSelectorDialog__locationCard"
+        >
+          <div
+            className="LocationCard__header"
+          >
+            <Text
+              className="LocationCard__title"
+              context="default"
+              inline={false}
+              size="large"
+              title="Amsterdam"
+            >
+              <p
+                className="Text--size_large LocationCard__title"
+                title="Amsterdam"
+              >
+                Amsterdam
+              </p>
+            </Text>
+            <button
+              className="LocationCard__delete-button"
+              onClick={[Function]}
+              type="button"
+            >
+              ×
+            </button>
+          </div>
+          <div
+            className="LocationCard__slider"
+          >
+            <Slider
+              initialValue={0}
+              max={100}
+              min={1}
+              onChange={[Function]}
+              step={1}
+              value={42}
+            >
+              <ComponentEnhancer(undefined)
+                activeDotStyle={Object {}}
+                className=""
+                disabled={false}
+                dotStyle={Object {}}
+                dots={false}
+                handle={[Function]}
+                handleStyle={
+                  Array [
+                    Object {},
+                  ]
+                }
+                included={true}
+                initialValue={0}
+                marks={Object {}}
+                max={100}
+                min={1}
+                onAfterChange={[Function]}
+                onBeforeChange={[Function]}
+                onChange={[Function]}
+                prefixCls="rc-slider"
+                railStyle={Object {}}
+                step={1}
+                trackStyle={
+                  Array [
+                    Object {},
+                  ]
+                }
+                value={42}
+                vertical={false}
+              >
+                <div
+                  className="rc-slider"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchStart={[Function]}
+                >
+                  <div
+                    className="rc-slider-rail"
+                    style={Object {}}
+                  />
+                  <Track
+                    className="rc-slider-track"
+                    included={true}
+                    length={41.41414141414141}
+                    offset={0}
+                    style={Object {}}
+                    vertical={false}
+                  >
+                    <div
+                      className="rc-slider-track"
+                      style={
+                        Object {
+                          "left": "0%",
+                          "width": "41.41414141414141%",
+                        }
+                      }
+                    />
+                  </Track>
+                  <Steps
+                    activeDotStyle={Object {}}
+                    dotStyle={Object {}}
+                    dots={false}
+                    included={true}
+                    lowerBound={1}
+                    marks={Object {}}
+                    max={100}
+                    min={1}
+                    prefixCls="rc-slider"
+                    step={1}
+                    upperBound={42}
+                    vertical={false}
+                  >
+                    <div
+                      className="rc-slider-step"
+                    />
+                  </Steps>
+                  <Handle
+                    className="rc-slider-handle"
+                    disabled={false}
+                    key="0"
+                    max={100}
+                    min={1}
+                    offset={41.41414141414141}
+                    prefixCls="rc-slider"
+                    style={Object {}}
+                    value={42}
+                    vertical={false}
+                  >
+                    <div
+                      aria-disabled={false}
+                      aria-valuemax={100}
+                      aria-valuemin={1}
+                      aria-valuenow={42}
+                      className="rc-slider-handle"
+                      onBlur={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDown={[Function]}
+                      role="slider"
+                      style={
+                        Object {
+                          "left": "41.41414141414141%",
+                        }
+                      }
+                      tabIndex={0}
+                    />
+                  </Handle>
+                  <Marks
+                    className="rc-slider-mark"
+                    included={true}
+                    lowerBound={1}
+                    marks={Object {}}
+                    max={100}
+                    min={1}
+                    onClickLabel={[Function]}
+                    upperBound={42}
+                    vertical={false}
+                  >
+                    <div
+                      className="rc-slider-mark"
+                    />
+                  </Marks>
+                </div>
+              </ComponentEnhancer(undefined)>
+            </Slider>
+            <Text
+              className="LocationCard__slider-label"
+              context="default"
+              inline={false}
+              size="small"
+            >
+              <p
+                className="Text--size_small LocationCard__slider-label"
+              >
+                + 42 km
+              </p>
+            </Text>
+          </div>
+        </li>
+      </LocationCard>
+      <LocationCard
+        As="li"
+        className="LocationSelectorDialog__locationCard"
+        distanceRadius={20}
+        key="ajdo-219a-j19v-0492"
+        locationId="ajdo-219a-j19v-0492"
+        locationTitle="Utrecht"
+        maxRadius={100}
+        minRadius={1}
+        onDelete={[MockFunction]}
+        onRadiusChange={[MockFunction]}
+        radiusStep={1}
+        sliderLabel="+ 20 km"
+      >
+        <li
+          className="LocationCard LocationSelectorDialog__locationCard"
+        >
+          <div
+            className="LocationCard__header"
+          >
+            <Text
+              className="LocationCard__title"
+              context="default"
+              inline={false}
+              size="large"
+              title="Utrecht"
+            >
+              <p
+                className="Text--size_large LocationCard__title"
+                title="Utrecht"
+              >
+                Utrecht
+              </p>
+            </Text>
+            <button
+              className="LocationCard__delete-button"
+              onClick={[Function]}
+              type="button"
+            >
+              ×
+            </button>
+          </div>
+          <div
+            className="LocationCard__slider"
+          >
+            <Slider
+              initialValue={0}
+              max={100}
+              min={1}
+              onChange={[Function]}
+              step={1}
+              value={20}
+            >
+              <ComponentEnhancer(undefined)
+                activeDotStyle={Object {}}
+                className=""
+                disabled={false}
+                dotStyle={Object {}}
+                dots={false}
+                handle={[Function]}
+                handleStyle={
+                  Array [
+                    Object {},
+                  ]
+                }
+                included={true}
+                initialValue={0}
+                marks={Object {}}
+                max={100}
+                min={1}
+                onAfterChange={[Function]}
+                onBeforeChange={[Function]}
+                onChange={[Function]}
+                prefixCls="rc-slider"
+                railStyle={Object {}}
+                step={1}
+                trackStyle={
+                  Array [
+                    Object {},
+                  ]
+                }
+                value={20}
+                vertical={false}
+              >
+                <div
+                  className="rc-slider"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchStart={[Function]}
+                >
+                  <div
+                    className="rc-slider-rail"
+                    style={Object {}}
+                  />
+                  <Track
+                    className="rc-slider-track"
+                    included={true}
+                    length={19.19191919191919}
+                    offset={0}
+                    style={Object {}}
+                    vertical={false}
+                  >
+                    <div
+                      className="rc-slider-track"
+                      style={
+                        Object {
+                          "left": "0%",
+                          "width": "19.19191919191919%",
+                        }
+                      }
+                    />
+                  </Track>
+                  <Steps
+                    activeDotStyle={Object {}}
+                    dotStyle={Object {}}
+                    dots={false}
+                    included={true}
+                    lowerBound={1}
+                    marks={Object {}}
+                    max={100}
+                    min={1}
+                    prefixCls="rc-slider"
+                    step={1}
+                    upperBound={20}
+                    vertical={false}
+                  >
+                    <div
+                      className="rc-slider-step"
+                    />
+                  </Steps>
+                  <Handle
+                    className="rc-slider-handle"
+                    disabled={false}
+                    key="0"
+                    max={100}
+                    min={1}
+                    offset={19.19191919191919}
+                    prefixCls="rc-slider"
+                    style={Object {}}
+                    value={20}
+                    vertical={false}
+                  >
+                    <div
+                      aria-disabled={false}
+                      aria-valuemax={100}
+                      aria-valuemin={1}
+                      aria-valuenow={20}
+                      className="rc-slider-handle"
+                      onBlur={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDown={[Function]}
+                      role="slider"
+                      style={
+                        Object {
+                          "left": "19.19191919191919%",
+                        }
+                      }
+                      tabIndex={0}
+                    />
+                  </Handle>
+                  <Marks
+                    className="rc-slider-mark"
+                    included={true}
+                    lowerBound={1}
+                    marks={Object {}}
+                    max={100}
+                    min={1}
+                    onClickLabel={[Function]}
+                    upperBound={20}
+                    vertical={false}
+                  >
+                    <div
+                      className="rc-slider-mark"
+                    />
+                  </Marks>
+                </div>
+              </ComponentEnhancer(undefined)>
+            </Slider>
+            <Text
+              className="LocationCard__slider-label"
+              context="default"
+              inline={false}
+              size="small"
+            >
+              <p
+                className="Text--size_small LocationCard__slider-label"
+              >
+                + 20 km
+              </p>
+            </Text>
+          </div>
+        </li>
+      </LocationCard>
+    </ul>
+    <Map
+      defaultArea={
+        Object {
+          "address": "NL",
+        }
+      }
+      mapContainerStyle={
+        Object {
+          "height": "100%",
+          "width": "100%",
+        }
+      }
+      markers={Array []}
+    >
+      <GoogleMap
+        mapContainerStyle={
+          Object {
+            "height": "100%",
+            "width": "100%",
+          }
+        }
+        onLoad={[Function]}
+        options={
+          Object {
+            "fullscreenControl": false,
+            "mapTypeControl": false,
+            "rotateControl": false,
+            "streetViewControl": false,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "height": "100%",
+              "width": "100%",
+            }
+          }
+        />
+      </GoogleMap>
+    </Map>
+  </div>
+</LocationSelectorDialog>
+`;

--- a/src/components/LocationSelector/LocationSelectorDialog/index.js
+++ b/src/components/LocationSelector/LocationSelectorDialog/index.js
@@ -1,0 +1,1 @@
+export { default } from './LocationSelectorDialog';

--- a/src/components/LocationSelector/LocationSelectorDialogWithGoogleLoader/LocationSelectorDialogWithGoogleLoader.js
+++ b/src/components/LocationSelector/LocationSelectorDialogWithGoogleLoader/LocationSelectorDialogWithGoogleLoader.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { LoadScriptNext } from '@react-google-maps/api';
+import { LoadingSpinner } from '../../../index';
+import LocationSelectorDialog from '../LocationSelectorDialog';
+
+const GOOGLE_API_LIBRARIES = ['places'];
+
+function LocationSelectorDialogWithGoogleLoader(props) {
+    const {
+        /** Google props */
+        apiKey,
+        language,
+        region,
+        additionalGoogleProps,
+
+        /** LocationCard props */
+        minRadius,
+        maxRadius,
+        radiusStep,
+        renderRadiusLabel,
+        onRemoveLocation,
+        doneLabel,
+
+        /** LocationAutocomplete props */
+        country,
+        placeTypes,
+        noSuggestionsPlaceholder,
+        showCountryInSuggestions,
+        onLocationAutocompleteError,
+
+        /** Internal use */
+        onCloseModal,
+        onAddLocation,
+        onUpdateLocation,
+        selectedLocations,
+        inputPlaceholder,
+        getMarkers,
+    } = props;
+
+    return (
+        <LoadScriptNext
+            googleMapsApiKey={apiKey}
+            language={language}
+            region={region}
+            loadingElement={<LoadingSpinner centerIn="parent" />}
+            libraries={GOOGLE_API_LIBRARIES}
+            {...additionalGoogleProps}
+        >
+            <LocationSelectorDialog
+                inputPlaceholder={inputPlaceholder}
+                minRadius={minRadius}
+                maxRadius={maxRadius}
+                radiusStep={radiusStep}
+                renderRadiusLabel={renderRadiusLabel}
+                onRemoveLocation={onRemoveLocation}
+                doneLabel={doneLabel}
+                country={country}
+                placeTypes={placeTypes}
+                noSuggestionsPlaceholder={noSuggestionsPlaceholder}
+                showCountryInSuggestions={showCountryInSuggestions}
+                onLocationAutocompleteError={onLocationAutocompleteError}
+                onUpdateLocation={onUpdateLocation}
+                selectedLocations={selectedLocations}
+                getMarkers={getMarkers}
+                onAddLocation={onAddLocation}
+                onCloseModal={onCloseModal}
+            />
+        </LoadScriptNext>
+    );
+}
+
+LocationSelectorDialogWithGoogleLoader.displayName = 'LocationSelectorDialogWithGoogleLoader';
+
+LocationSelectorDialogWithGoogleLoader.propTypes = {
+    /** Google api key */
+    apiKey: PropTypes.string.isRequired,
+    /** language in which suggestions should be displayed */
+    language: PropTypes.string.isRequired,
+    /** Regional setting for the map. By default Google uses US.
+     * For details see: https://developers.google.com/maps/documentation/javascript/localization#Region
+     */
+    region: PropTypes.string,
+    /** other props to pass to the google loader. For details see: https://react-google-maps-api-docs.netlify.com/#loadscriptnext */
+    additionalGoogleProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+    /** LocationSelectorDialog props */
+    ...LocationSelectorDialog.propTypes,
+};
+
+LocationSelectorDialogWithGoogleLoader.defaultProps = {
+    additionalGoogleProps: {},
+    region: undefined,
+    ...LocationSelectorDialog.defaultProps,
+};
+
+export default LocationSelectorDialogWithGoogleLoader;

--- a/src/components/LocationSelector/LocationSelectorDialogWithGoogleLoader/LocationSelectorDialogWithGoogleLoader.js
+++ b/src/components/LocationSelector/LocationSelectorDialogWithGoogleLoader/LocationSelectorDialogWithGoogleLoader.js
@@ -84,13 +84,13 @@ LocationSelectorDialogWithGoogleLoader.propTypes = {
     /** other props to pass to the google loader. For details see: https://react-google-maps-api-docs.netlify.com/#loadscriptnext */
     additionalGoogleProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     /** LocationSelectorDialog props */
-    ...LocationSelectorDialog.propTypes,
+    // ...LocationSelectorDialog.propTypes,
 };
 
 LocationSelectorDialogWithGoogleLoader.defaultProps = {
     additionalGoogleProps: {},
     region: undefined,
-    ...LocationSelectorDialog.defaultProps,
+    // ...LocationSelectorDialog.defaultProps,
 };
 
 export default LocationSelectorDialogWithGoogleLoader;

--- a/src/components/LocationSelector/LocationSelectorDialogWithGoogleLoader/__tests__/LocationSelectorDialogWithGoogleLoader.spec.js
+++ b/src/components/LocationSelector/LocationSelectorDialogWithGoogleLoader/__tests__/LocationSelectorDialogWithGoogleLoader.spec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import toJson from 'enzyme-to-json';
+import LocationSelectorDialogWithGoogleLoader from '..';
+
+describe('<LocationSelectorDialogWithGoogleLoader/> that loads google api and renders a Location selector dialog', () => {
+    it('should render with default props', () => {
+        const wrapper = mount(
+            <LocationSelectorDialogWithGoogleLoader
+                apiKey="someKey"
+                language="en"
+                inputPlaceholder="Location"
+                minRadius={1}
+                maxRadius={100}
+                radiusStep={5}
+                renderRadiusLabel={jest.fn()}
+                onRemoveLocation={jest.fn()}
+                doneLabel="Done"
+                country="NL"
+                noSuggestionsPlaceholder="No suggestions"
+                placeTypes={['(regions)']}
+                onUpdateLocation={jest.fn()}
+                selectedLocations={[]}
+                getMarkers={() => []}
+                onAddLocation={jest.fn()}
+                onCloseModal={jest.fn()}
+            />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/src/components/LocationSelector/LocationSelectorDialogWithGoogleLoader/__tests__/__snapshots__/LocationSelectorDialogWithGoogleLoader.spec.js.snap
+++ b/src/components/LocationSelector/LocationSelectorDialogWithGoogleLoader/__tests__/__snapshots__/LocationSelectorDialogWithGoogleLoader.spec.js.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LocationSelectorDialogWithGoogleLoader/> that loads google api and renders a Location selector dialog should render with default props 1`] = `
+<LocationSelectorDialogWithGoogleLoader
+  additionalGoogleProps={Object {}}
+  apiKey="someKey"
+  country="NL"
+  doneLabel="Done"
+  getMarkers={[Function]}
+  inputPlaceholder="Location"
+  language="en"
+  maxRadius={100}
+  minRadius={1}
+  noSuggestionsPlaceholder="No suggestions"
+  onAddLocation={[MockFunction]}
+  onCloseModal={[MockFunction]}
+  onRemoveLocation={[MockFunction]}
+  onUpdateLocation={[MockFunction]}
+  placeTypes={
+    Array [
+      "(regions)",
+    ]
+  }
+  radiusStep={5}
+  renderRadiusLabel={[MockFunction]}
+  selectedLocations={Array []}
+>
+  <Memo(LoadScriptNext)
+    googleMapsApiKey="someKey"
+    language="en"
+    libraries={
+      Array [
+        "places",
+      ]
+    }
+    loadingElement={
+      <LoadingSpinner
+        centerIn="parent"
+        context="brand"
+        hidden={false}
+        size={null}
+      />
+    }
+  >
+    <LoadingSpinner
+      centerIn="parent"
+      context="brand"
+      hidden={false}
+      size={null}
+    >
+      <div
+        aria-busy={true}
+        aria-hidden={false}
+        className="LoadingSpinner LoadingSpinner--centerIn_parent"
+        role="status"
+      >
+        <svg
+          className="LoadingSpinner__svg"
+          style={null}
+          viewBox={
+            Array [
+              0,
+              0,
+              44,
+              44,
+            ]
+          }
+        >
+          <circle
+            className="LoadingSpinner__path LoadingSpinner__path--context_brand"
+            cx="22"
+            cy="22"
+            fill="none"
+            r="20"
+            strokeWidth="4"
+          />
+        </svg>
+      </div>
+    </LoadingSpinner>
+  </Memo(LoadScriptNext)>
+</LocationSelectorDialogWithGoogleLoader>
+`;

--- a/src/components/LocationSelector/LocationSelectorDialogWithGoogleLoader/index.js
+++ b/src/components/LocationSelector/LocationSelectorDialogWithGoogleLoader/index.js
@@ -1,0 +1,1 @@
+export { default } from './LocationSelectorDialogWithGoogleLoader';

--- a/src/components/LocationSelector/__tests__/__snapshots__/LocationSelector.spec.js.snap
+++ b/src/components/LocationSelector/__tests__/__snapshots__/LocationSelector.spec.js.snap
@@ -2,16 +2,21 @@
 
 exports[`LocationSelector component should render LocationSelector properly when modal is open 1`] = `
 <LocationSelector
+  additionalGoogleProps={Object {}}
+  apiKey="apiKey"
+  clearLabel="Clear"
   country="NL"
   doneLabel="doneLabel"
-  getMarkers={[Function]}
   inputPlaceholder="inputPlaceholder"
+  language="en"
   maxRadius={100}
   minRadius={1}
+  modalContentLabel="Location selection dialog"
   noSuggestionsPlaceholder="noSuggestionsPlaceholder"
   onAddLocation={[MockFunction]}
-  onCloseModal={[MockFunction]}
+  onBlur={[Function]}
   onLocationAutocompleteError={[MockFunction]}
+  onRemoveAllLocations={[MockFunction]}
   onRemoveLocation={[MockFunction]}
   onUpdateLocation={[MockFunction]}
   placeTypes={
@@ -19,7 +24,9 @@ exports[`LocationSelector component should render LocationSelector properly when
       "(regions)",
     ]
   }
+  radiusDefaultValue={2}
   radiusStep={1}
+  radiusUnits="km"
   renderRadiusLabel={[Function]}
   selectedLocations={
     Array [
@@ -45,652 +52,376 @@ exports[`LocationSelector component should render LocationSelector properly when
       },
     ]
   }
+  selectionPlaceholder={null}
   showCountryInSuggestions={true}
 >
-  <div
-    className="LocationSelector__inputLine"
-  >
-    <LocationAutocomplete
-      className="LocationSelector__searchField"
-      country="NL"
-      hidePoweredByGoogleLogo={true}
-      inputPlaceholder="inputPlaceholder"
-      isFocused={true}
-      noSuggestionsPlaceholder="noSuggestionsPlaceholder"
-      onError={[MockFunction]}
-      onSelectionChange={[MockFunction]}
-      placeTypes={
-        Array [
-          "(regions)",
-        ]
-      }
-      showCountryInSuggestions={true}
+  <div>
+    <FieldWrapper
+      className="LocationSelector__mainTextInputWrapper"
+      clearLabel="Clear"
+      isFocused={false}
+      onClear={[MockFunction]}
+      onClick={[Function]}
+      showClearButton={true}
     >
-      <Autosuggest
-        className="LocationSelector__searchField"
-        clearTitle=""
-        getSuggestions={null}
-        iconNode={
-          <FaMapMarkerAlt
-            className="LocationAutocomplete__icon"
-          />
-        }
-        inputPlaceholder="inputPlaceholder"
-        isFocused={true}
-        isLoading={false}
-        isMultiselect={false}
-        isProminent={false}
-        listRenderer={[Function]}
-        noSuggestionsPlaceholder="noSuggestionsPlaceholder"
-        onBlur={[Function]}
-        onClearAllSelected={null}
-        onInputValueChange={[Function]}
-        onSelectionChange={[Function]}
-        selectedPlaceholder=""
-        selectedSuggestions={null}
-        showClearButton={false}
-        suggestionToString={[Function]}
+      <div
+        className="FieldWrapper LocationSelector__mainTextInputWrapper"
+        onClick={[Function]}
       >
         <div
-          className="Autosuggest LocationSelector__searchField"
+          className="FieldWrapper__content"
         >
-          <Downshift
-            defaultHighlightedIndex={0}
-            defaultIsOpen={false}
-            environment={[Window]}
-            getA11yStatusMessage={[Function]}
-            inputValue=""
-            itemToString={[Function]}
-            onChange={[Function]}
-            onInputValueChange={[Function]}
-            onOuterClick={[Function]}
-            onSelect={[Function]}
-            onStateChange={[Function]}
-            onUserAction={[Function]}
-            scrollIntoView={[Function]}
-            selectedItemChanged={[Function]}
-            stateReducer={[Function]}
-            suppressRefError={false}
+          <FaMapMarkerAlt
+            className="LocationSelector__icon"
           >
-            <div
-              aria-expanded={false}
-              aria-haspopup="listbox"
-              aria-labelledby="downshift-1-label"
-              aria-owns={null}
-              className="Autosuggest__main Autosuggest__main--focused"
-              role="combobox"
+            <IconBase
+              attr={
+                Object {
+                  "viewBox": "0 0 384 512",
+                }
+              }
+              className="LocationSelector__icon"
             >
-              <FieldWrapper
-                className="Autosuggest__field"
-                clearLabel=""
-                isFocused={true}
-                onClear={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                showClearButton={false}
+              <svg
+                className="LocationSelector__icon"
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 384 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
+                  key="0"
+                />
+              </svg>
+            </IconBase>
+          </FaMapMarkerAlt>
+          <Text
+            className="LocationSelector__mainTextInput LocationSelector__mainTextInput--muted"
+            context="default"
+            inline={false}
+            size="normal"
+          >
+            <p
+              className="LocationSelector__mainTextInput LocationSelector__mainTextInput--muted"
+            >
+              inputPlaceholder
+            </p>
+          </Text>
+        </div>
+        <Button
+          className="FieldWrapper__clearButton"
+          context="link"
+          disabled={false}
+          href={null}
+          isBlock={false}
+          isInline={true}
+          onClick={[Function]}
+          size="normal"
+          type="button"
+        >
+          <button
+            className="Button Button--context_link Button--isInline FieldWrapper__clearButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            Clear
+          </button>
+        </Button>
+      </div>
+    </FieldWrapper>
+    <Modal
+      ariaHideApp={false}
+      className="LocationSelector__modal"
+      contentLabel="Location selection dialog"
+      isOpen={true}
+      onRequestClose={[Function]}
+    >
+      <Modal
+        ariaHideApp={false}
+        bodyOpenClassName="ReactModal__Body--open"
+        className={
+          Object {
+            "afterOpen": "Modal__content--entered",
+            "base": "Modal__content LocationSelector__modal",
+            "beforeClose": "Modal__content--exited",
+          }
+        }
+        closeTimeoutMS={300}
+        contentLabel="Location selection dialog"
+        isOpen={true}
+        onRequestClose={[Function]}
+        overlayClassName={
+          Object {
+            "afterOpen": "Modal__overlay--entered",
+            "base": "Modal__overlay",
+            "beforeClose": "Modal__overlay--exited",
+          }
+        }
+        parentSelector={[Function]}
+        portalClassName="LocationSelector__modal"
+        role="dialog"
+        shouldCloseOnEsc={true}
+        shouldCloseOnOverlayClick={true}
+        shouldFocusAfterRender={true}
+        shouldReturnFocusAfterClose={true}
+      >
+        <Portal
+          containerInfo={
+            <div
+              class="LocationSelector__modal"
+            >
+              <div
+                class="Modal__overlay Modal__overlay--entered"
               >
                 <div
-                  className="FieldWrapper FieldWrapper--isFocused Autosuggest__field"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
+                  aria-label="Location selection dialog"
+                  class="Modal__content LocationSelector__modal Modal__content--entered"
+                  role="dialog"
+                  tabindex="-1"
                 >
                   <div
-                    className="FieldWrapper__content"
+                    aria-busy="true"
+                    aria-hidden="false"
+                    class="LoadingSpinner LoadingSpinner--centerIn_parent"
+                    role="status"
                   >
-                    <div
-                      className="Autosuggest__wrapper Autosuggest__wrapper--focused"
-                      role="searchbox"
-                      tabIndex="0"
+                    <svg
+                      class="LoadingSpinner__svg"
+                      viewBox="0,0,44,44"
                     >
-                      <FaMapMarkerAlt
-                        className="Autosuggest__spacedElem LocationAutocomplete__icon"
-                      >
-                        <IconBase
-                          attr={
-                            Object {
-                              "viewBox": "0 0 384 512",
-                            }
-                          }
-                          className="Autosuggest__spacedElem LocationAutocomplete__icon"
-                        >
-                          <svg
-                            className="Autosuggest__spacedElem LocationAutocomplete__icon"
-                            fill="currentColor"
-                            height="1em"
-                            stroke="currentColor"
-                            strokeWidth="0"
-                            style={
-                              Object {
-                                "color": undefined,
-                              }
-                            }
-                            viewBox="0 0 384 512"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
-                              key="0"
-                            />
-                          </svg>
-                        </IconBase>
-                      </FaMapMarkerAlt>
-                      <input
-                        aria-activedescendant={null}
-                        aria-autocomplete="list"
-                        aria-controls={null}
-                        aria-labelledby="downshift-1-label"
-                        autoComplete="off"
-                        className="Autosuggest__input"
-                        id="downshift-1-input"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onKeyDown={[Function]}
-                        placeholder="inputPlaceholder"
-                        value=""
+                      <circle
+                        class="LoadingSpinner__path LoadingSpinner__path--context_brand"
+                        cx="22"
+                        cy="22"
+                        fill="none"
+                        r="20"
+                        stroke-width="4"
                       />
-                    </div>
-                    <List
-                      aria-labelledby="downshift-1-label"
-                      className="Autosuggest__list--focused"
-                      doSelectOnNavigate={false}
-                      id="downshift-1-menu"
-                      isControlledNavigation={true}
-                      isDivided={false}
-                      role="listbox"
-                    >
-                      <ul
-                        aria-labelledby="downshift-1-label"
-                        className="List Autosuggest__list--focused"
-                        id="downshift-1-menu"
-                        role="listbox"
-                      />
-                    </List>
+                    </svg>
                   </div>
                 </div>
-              </FieldWrapper>
+              </div>
             </div>
-          </Downshift>
-        </div>
-      </Autosuggest>
-    </LocationAutocomplete>
-    <Button
-      className="LocationSelector__button"
-      context="brand"
-      disabled={false}
-      href={null}
-      isBlock={false}
-      isInline={false}
-      onClick={[MockFunction]}
-      size="normal"
-      type="button"
-    >
-      <button
-        className="Button Button--context_brand LocationSelector__button"
-        disabled={false}
-        onClick={[MockFunction]}
-        type="button"
-      >
-        doneLabel
-      </button>
-    </Button>
-  </div>
-  <div
-    className="LocationSelector__locationsWrapper"
-  >
-    <ul
-      className="LocationSelector__locationCardsContainer"
-    >
-      <LocationCard
-        As="li"
-        className="LocationSelector__locationCard"
-        distanceRadius={42}
-        key="ajdo-219a-j19v-0491"
-        locationId="ajdo-219a-j19v-0491"
-        locationTitle="Amsterdam"
-        maxRadius={100}
-        minRadius={1}
-        onDelete={[MockFunction]}
-        onRadiusChange={[MockFunction]}
-        radiusStep={1}
-        sliderLabel="+ 42 km"
-      >
-        <li
-          className="LocationCard LocationSelector__locationCard"
-        >
-          <div
-            className="LocationCard__header"
-          >
-            <Text
-              className="LocationCard__title"
-              context="default"
-              inline={false}
-              size="large"
-              title="Amsterdam"
-            >
-              <p
-                className="Text--size_large LocationCard__title"
-                title="Amsterdam"
-              >
-                Amsterdam
-              </p>
-            </Text>
-            <button
-              className="LocationCard__delete-button"
-              onClick={[Function]}
-              type="button"
-            >
-              ×
-            </button>
-          </div>
-          <div
-            className="LocationCard__slider"
-          >
-            <Slider
-              initialValue={0}
-              max={100}
-              min={1}
-              onChange={[Function]}
-              step={1}
-              value={42}
-            >
-              <ComponentEnhancer(undefined)
-                activeDotStyle={Object {}}
-                className=""
-                disabled={false}
-                dotStyle={Object {}}
-                dots={false}
-                handle={[Function]}
-                handleStyle={
-                  Array [
-                    Object {},
-                  ]
-                }
-                included={true}
-                initialValue={0}
-                marks={Object {}}
-                max={100}
-                min={1}
-                onAfterChange={[Function]}
-                onBeforeChange={[Function]}
-                onChange={[Function]}
-                prefixCls="rc-slider"
-                railStyle={Object {}}
-                step={1}
-                trackStyle={
-                  Array [
-                    Object {},
-                  ]
-                }
-                value={42}
-                vertical={false}
-              >
-                <div
-                  className="rc-slider"
-                  onBlur={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchStart={[Function]}
-                >
-                  <div
-                    className="rc-slider-rail"
-                    style={Object {}}
-                  />
-                  <Track
-                    className="rc-slider-track"
-                    included={true}
-                    length={41.41414141414141}
-                    offset={0}
-                    style={Object {}}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-track"
-                      style={
-                        Object {
-                          "left": "0%",
-                          "width": "41.41414141414141%",
-                        }
-                      }
-                    />
-                  </Track>
-                  <Steps
-                    activeDotStyle={Object {}}
-                    dotStyle={Object {}}
-                    dots={false}
-                    included={true}
-                    lowerBound={1}
-                    marks={Object {}}
-                    max={100}
-                    min={1}
-                    prefixCls="rc-slider"
-                    step={1}
-                    upperBound={42}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-step"
-                    />
-                  </Steps>
-                  <Handle
-                    className="rc-slider-handle"
-                    disabled={false}
-                    key="0"
-                    max={100}
-                    min={1}
-                    offset={41.41414141414141}
-                    prefixCls="rc-slider"
-                    style={Object {}}
-                    value={42}
-                    vertical={false}
-                  >
-                    <div
-                      aria-disabled={false}
-                      aria-valuemax={100}
-                      aria-valuemin={1}
-                      aria-valuenow={42}
-                      className="rc-slider-handle"
-                      onBlur={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      role="slider"
-                      style={
-                        Object {
-                          "left": "41.41414141414141%",
-                        }
-                      }
-                      tabIndex={0}
-                    />
-                  </Handle>
-                  <Marks
-                    className="rc-slider-mark"
-                    included={true}
-                    lowerBound={1}
-                    marks={Object {}}
-                    max={100}
-                    min={1}
-                    onClickLabel={[Function]}
-                    upperBound={42}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-mark"
-                    />
-                  </Marks>
-                </div>
-              </ComponentEnhancer(undefined)>
-            </Slider>
-            <Text
-              className="LocationCard__slider-label"
-              context="default"
-              inline={false}
-              size="small"
-            >
-              <p
-                className="Text--size_small LocationCard__slider-label"
-              >
-                + 42 km
-              </p>
-            </Text>
-          </div>
-        </li>
-      </LocationCard>
-      <LocationCard
-        As="li"
-        className="LocationSelector__locationCard"
-        distanceRadius={20}
-        key="ajdo-219a-j19v-0492"
-        locationId="ajdo-219a-j19v-0492"
-        locationTitle="Utrecht"
-        maxRadius={100}
-        minRadius={1}
-        onDelete={[MockFunction]}
-        onRadiusChange={[MockFunction]}
-        radiusStep={1}
-        sliderLabel="+ 20 km"
-      >
-        <li
-          className="LocationCard LocationSelector__locationCard"
-        >
-          <div
-            className="LocationCard__header"
-          >
-            <Text
-              className="LocationCard__title"
-              context="default"
-              inline={false}
-              size="large"
-              title="Utrecht"
-            >
-              <p
-                className="Text--size_large LocationCard__title"
-                title="Utrecht"
-              >
-                Utrecht
-              </p>
-            </Text>
-            <button
-              className="LocationCard__delete-button"
-              onClick={[Function]}
-              type="button"
-            >
-              ×
-            </button>
-          </div>
-          <div
-            className="LocationCard__slider"
-          >
-            <Slider
-              initialValue={0}
-              max={100}
-              min={1}
-              onChange={[Function]}
-              step={1}
-              value={20}
-            >
-              <ComponentEnhancer(undefined)
-                activeDotStyle={Object {}}
-                className=""
-                disabled={false}
-                dotStyle={Object {}}
-                dots={false}
-                handle={[Function]}
-                handleStyle={
-                  Array [
-                    Object {},
-                  ]
-                }
-                included={true}
-                initialValue={0}
-                marks={Object {}}
-                max={100}
-                min={1}
-                onAfterChange={[Function]}
-                onBeforeChange={[Function]}
-                onChange={[Function]}
-                prefixCls="rc-slider"
-                railStyle={Object {}}
-                step={1}
-                trackStyle={
-                  Array [
-                    Object {},
-                  ]
-                }
-                value={20}
-                vertical={false}
-              >
-                <div
-                  className="rc-slider"
-                  onBlur={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchStart={[Function]}
-                >
-                  <div
-                    className="rc-slider-rail"
-                    style={Object {}}
-                  />
-                  <Track
-                    className="rc-slider-track"
-                    included={true}
-                    length={19.19191919191919}
-                    offset={0}
-                    style={Object {}}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-track"
-                      style={
-                        Object {
-                          "left": "0%",
-                          "width": "19.19191919191919%",
-                        }
-                      }
-                    />
-                  </Track>
-                  <Steps
-                    activeDotStyle={Object {}}
-                    dotStyle={Object {}}
-                    dots={false}
-                    included={true}
-                    lowerBound={1}
-                    marks={Object {}}
-                    max={100}
-                    min={1}
-                    prefixCls="rc-slider"
-                    step={1}
-                    upperBound={20}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-step"
-                    />
-                  </Steps>
-                  <Handle
-                    className="rc-slider-handle"
-                    disabled={false}
-                    key="0"
-                    max={100}
-                    min={1}
-                    offset={19.19191919191919}
-                    prefixCls="rc-slider"
-                    style={Object {}}
-                    value={20}
-                    vertical={false}
-                  >
-                    <div
-                      aria-disabled={false}
-                      aria-valuemax={100}
-                      aria-valuemin={1}
-                      aria-valuenow={20}
-                      className="rc-slider-handle"
-                      onBlur={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      role="slider"
-                      style={
-                        Object {
-                          "left": "19.19191919191919%",
-                        }
-                      }
-                      tabIndex={0}
-                    />
-                  </Handle>
-                  <Marks
-                    className="rc-slider-mark"
-                    included={true}
-                    lowerBound={1}
-                    marks={Object {}}
-                    max={100}
-                    min={1}
-                    onClickLabel={[Function]}
-                    upperBound={20}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-mark"
-                    />
-                  </Marks>
-                </div>
-              </ComponentEnhancer(undefined)>
-            </Slider>
-            <Text
-              className="LocationCard__slider-label"
-              context="default"
-              inline={false}
-              size="small"
-            >
-              <p
-                className="Text--size_small LocationCard__slider-label"
-              >
-                + 20 km
-              </p>
-            </Text>
-          </div>
-        </li>
-      </LocationCard>
-    </ul>
-    <Map
-      defaultArea={
-        Object {
-          "address": "NL",
-        }
-      }
-      mapContainerStyle={
-        Object {
-          "height": "100%",
-          "width": "100%",
-        }
-      }
-      markers={Array []}
-    >
-      <GoogleMap
-        mapContainerStyle={
-          Object {
-            "height": "100%",
-            "width": "100%",
           }
-        }
-        onLoad={[Function]}
-        options={
-          Object {
-            "fullscreenControl": false,
-            "mapTypeControl": false,
-            "rotateControl": false,
-            "streetViewControl": false,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "height": "100%",
-              "width": "100%",
+        >
+          <ModalPortal
+            ariaHideApp={false}
+            bodyOpenClassName="ReactModal__Body--open"
+            className={
+              Object {
+                "afterOpen": "Modal__content--entered",
+                "base": "Modal__content LocationSelector__modal",
+                "beforeClose": "Modal__content--exited",
+              }
             }
-          }
-        />
-      </GoogleMap>
-    </Map>
+            closeTimeoutMS={300}
+            contentLabel="Location selection dialog"
+            defaultStyles={
+              Object {
+                "content": Object {
+                  "WebkitOverflowScrolling": "touch",
+                  "background": "#fff",
+                  "border": "1px solid #ccc",
+                  "borderRadius": "4px",
+                  "bottom": "40px",
+                  "left": "40px",
+                  "outline": "none",
+                  "overflow": "auto",
+                  "padding": "20px",
+                  "position": "absolute",
+                  "right": "40px",
+                  "top": "40px",
+                },
+                "overlay": Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.75)",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "fixed",
+                  "right": 0,
+                  "top": 0,
+                },
+              }
+            }
+            isOpen={true}
+            onRequestClose={[Function]}
+            overlayClassName={
+              Object {
+                "afterOpen": "Modal__overlay--entered",
+                "base": "Modal__overlay",
+                "beforeClose": "Modal__overlay--exited",
+              }
+            }
+            parentSelector={[Function]}
+            portalClassName="LocationSelector__modal"
+            role="dialog"
+            shouldCloseOnEsc={true}
+            shouldCloseOnOverlayClick={true}
+            shouldFocusAfterRender={true}
+            shouldReturnFocusAfterClose={true}
+            style={
+              Object {
+                "content": Object {},
+                "overlay": Object {},
+              }
+            }
+          >
+            <div
+              className="Modal__overlay Modal__overlay--entered"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              style={Object {}}
+            >
+              <div
+                aria-label="Location selection dialog"
+                className="Modal__content LocationSelector__modal Modal__content--entered"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="dialog"
+                style={Object {}}
+                tabIndex="-1"
+              >
+                <LocationSelectorDialogWithGoogleLoader
+                  additionalGoogleProps={Object {}}
+                  apiKey="apiKey"
+                  country="NL"
+                  doneLabel="doneLabel"
+                  getMarkers={[Function]}
+                  inputPlaceholder="inputPlaceholder"
+                  language="en"
+                  maxRadius={100}
+                  minRadius={1}
+                  noSuggestionsPlaceholder="noSuggestionsPlaceholder"
+                  onAddLocation={[Function]}
+                  onCloseModal={[Function]}
+                  onLocationAutocompleteError={[MockFunction]}
+                  onRemoveLocation={[MockFunction]}
+                  onUpdateLocation={[MockFunction]}
+                  placeTypes={
+                    Array [
+                      "(regions)",
+                    ]
+                  }
+                  radiusStep={1}
+                  renderRadiusLabel={[Function]}
+                  selectedLocations={
+                    Array [
+                      Object {
+                        "center": Object {
+                          "lat": 52.3666969,
+                          "lng": 4.894539799999961,
+                        },
+                        "description": "Amsterdam",
+                        "id": "ajdo-219a-j19v-0491",
+                        "radius": 42,
+                        "sliderLabel": "42km",
+                      },
+                      Object {
+                        "center": Object {
+                          "lat": 52.09073739999999,
+                          "lng": 5.121420100000023,
+                        },
+                        "description": "Utrecht",
+                        "id": "ajdo-219a-j19v-0492",
+                        "radius": 20,
+                        "sliderLabel": "20km",
+                      },
+                    ]
+                  }
+                  showCountryInSuggestions={true}
+                >
+                  <Memo(LoadScriptNext)
+                    googleMapsApiKey="apiKey"
+                    language="en"
+                    libraries={
+                      Array [
+                        "places",
+                      ]
+                    }
+                    loadingElement={
+                      <LoadingSpinner
+                        centerIn="parent"
+                        context="brand"
+                        hidden={false}
+                        size={null}
+                      />
+                    }
+                  >
+                    <LoadingSpinner
+                      centerIn="parent"
+                      context="brand"
+                      hidden={false}
+                      size={null}
+                    >
+                      <div
+                        aria-busy={true}
+                        aria-hidden={false}
+                        className="LoadingSpinner LoadingSpinner--centerIn_parent"
+                        role="status"
+                      >
+                        <svg
+                          className="LoadingSpinner__svg"
+                          style={null}
+                          viewBox={
+                            Array [
+                              0,
+                              0,
+                              44,
+                              44,
+                            ]
+                          }
+                        >
+                          <circle
+                            className="LoadingSpinner__path LoadingSpinner__path--context_brand"
+                            cx="22"
+                            cy="22"
+                            fill="none"
+                            r="20"
+                            strokeWidth="4"
+                          />
+                        </svg>
+                      </div>
+                    </LoadingSpinner>
+                  </Memo(LoadScriptNext)>
+                </LocationSelectorDialogWithGoogleLoader>
+              </div>
+            </div>
+          </ModalPortal>
+        </Portal>
+      </Modal>
+    </Modal>
   </div>
 </LocationSelector>
 `;
 
 exports[`LocationSelector component should render LocationSelector propertly when modal is closed 1`] = `
 <LocationSelector
+  additionalGoogleProps={Object {}}
+  apiKey="apiKey"
+  clearLabel="Clear"
   country="NL"
   doneLabel="doneLabel"
-  getMarkers={[Function]}
   inputPlaceholder="inputPlaceholder"
+  language="en"
   maxRadius={100}
   minRadius={1}
+  modalContentLabel="Location selection dialog"
   noSuggestionsPlaceholder="noSuggestionsPlaceholder"
   onAddLocation={[MockFunction]}
-  onCloseModal={[MockFunction]}
+  onBlur={[Function]}
   onLocationAutocompleteError={[MockFunction]}
+  onRemoveAllLocations={[MockFunction]}
   onRemoveLocation={[MockFunction]}
   onUpdateLocation={[MockFunction]}
   placeTypes={
@@ -698,7 +429,9 @@ exports[`LocationSelector component should render LocationSelector propertly whe
       "(regions)",
     ]
   }
+  radiusDefaultValue={2}
   radiusStep={1}
+  radiusUnits="km"
   renderRadiusLabel={[Function]}
   selectedLocations={
     Array [
@@ -724,636 +457,200 @@ exports[`LocationSelector component should render LocationSelector propertly whe
       },
     ]
   }
+  selectionPlaceholder={null}
   showCountryInSuggestions={true}
 >
-  <div
-    className="LocationSelector__inputLine"
-  >
-    <LocationAutocomplete
-      className="LocationSelector__searchField"
-      country="NL"
-      hidePoweredByGoogleLogo={true}
-      inputPlaceholder="inputPlaceholder"
-      isFocused={true}
-      noSuggestionsPlaceholder="noSuggestionsPlaceholder"
-      onError={[MockFunction]}
-      onSelectionChange={[MockFunction]}
-      placeTypes={
-        Array [
-          "(regions)",
-        ]
-      }
-      showCountryInSuggestions={true}
+  <div>
+    <FieldWrapper
+      className="LocationSelector__mainTextInputWrapper"
+      clearLabel="Clear"
+      isFocused={false}
+      onClear={[MockFunction]}
+      onClick={[Function]}
+      showClearButton={true}
     >
-      <Autosuggest
-        className="LocationSelector__searchField"
-        clearTitle=""
-        getSuggestions={null}
-        iconNode={
+      <div
+        className="FieldWrapper LocationSelector__mainTextInputWrapper"
+        onClick={[Function]}
+      >
+        <div
+          className="FieldWrapper__content"
+        >
           <FaMapMarkerAlt
-            className="LocationAutocomplete__icon"
-          />
-        }
-        inputPlaceholder="inputPlaceholder"
-        isFocused={true}
-        isLoading={false}
-        isMultiselect={false}
-        isProminent={false}
-        listRenderer={[Function]}
-        noSuggestionsPlaceholder="noSuggestionsPlaceholder"
-        onBlur={[Function]}
-        onClearAllSelected={null}
-        onInputValueChange={[Function]}
-        onSelectionChange={[Function]}
-        selectedPlaceholder=""
-        selectedSuggestions={null}
-        showClearButton={false}
-        suggestionToString={[Function]}
-      >
-        <div
-          className="Autosuggest LocationSelector__searchField"
-        >
-          <Downshift
-            defaultHighlightedIndex={0}
-            defaultIsOpen={false}
-            environment={[Window]}
-            getA11yStatusMessage={[Function]}
-            inputValue=""
-            itemToString={[Function]}
-            onChange={[Function]}
-            onInputValueChange={[Function]}
-            onOuterClick={[Function]}
-            onSelect={[Function]}
-            onStateChange={[Function]}
-            onUserAction={[Function]}
-            scrollIntoView={[Function]}
-            selectedItemChanged={[Function]}
-            stateReducer={[Function]}
-            suppressRefError={false}
+            className="LocationSelector__icon"
           >
-            <div
-              aria-expanded={false}
-              aria-haspopup="listbox"
-              aria-labelledby="downshift-0-label"
-              aria-owns={null}
-              className="Autosuggest__main Autosuggest__main--focused"
-              role="combobox"
+            <IconBase
+              attr={
+                Object {
+                  "viewBox": "0 0 384 512",
+                }
+              }
+              className="LocationSelector__icon"
             >
-              <FieldWrapper
-                className="Autosuggest__field"
-                clearLabel=""
-                isFocused={true}
-                onClear={[Function]}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                showClearButton={false}
+              <svg
+                className="LocationSelector__icon"
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 384 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <div
-                  className="FieldWrapper FieldWrapper--isFocused Autosuggest__field"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                >
-                  <div
-                    className="FieldWrapper__content"
-                  >
-                    <div
-                      className="Autosuggest__wrapper Autosuggest__wrapper--focused"
-                      role="searchbox"
-                      tabIndex="0"
-                    >
-                      <FaMapMarkerAlt
-                        className="Autosuggest__spacedElem LocationAutocomplete__icon"
-                      >
-                        <IconBase
-                          attr={
-                            Object {
-                              "viewBox": "0 0 384 512",
-                            }
-                          }
-                          className="Autosuggest__spacedElem LocationAutocomplete__icon"
-                        >
-                          <svg
-                            className="Autosuggest__spacedElem LocationAutocomplete__icon"
-                            fill="currentColor"
-                            height="1em"
-                            stroke="currentColor"
-                            strokeWidth="0"
-                            style={
-                              Object {
-                                "color": undefined,
-                              }
-                            }
-                            viewBox="0 0 384 512"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
-                              key="0"
-                            />
-                          </svg>
-                        </IconBase>
-                      </FaMapMarkerAlt>
-                      <input
-                        aria-activedescendant={null}
-                        aria-autocomplete="list"
-                        aria-controls={null}
-                        aria-labelledby="downshift-0-label"
-                        autoComplete="off"
-                        className="Autosuggest__input"
-                        id="downshift-0-input"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onKeyDown={[Function]}
-                        placeholder="inputPlaceholder"
-                        value=""
-                      />
-                    </div>
-                    <List
-                      aria-labelledby="downshift-0-label"
-                      className="Autosuggest__list--focused"
-                      doSelectOnNavigate={false}
-                      id="downshift-0-menu"
-                      isControlledNavigation={true}
-                      isDivided={false}
-                      role="listbox"
-                    >
-                      <ul
-                        aria-labelledby="downshift-0-label"
-                        className="List Autosuggest__list--focused"
-                        id="downshift-0-menu"
-                        role="listbox"
-                      />
-                    </List>
-                  </div>
-                </div>
-              </FieldWrapper>
-            </div>
-          </Downshift>
+                <path
+                  d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"
+                  key="0"
+                />
+              </svg>
+            </IconBase>
+          </FaMapMarkerAlt>
+          <Text
+            className="LocationSelector__mainTextInput LocationSelector__mainTextInput--muted"
+            context="default"
+            inline={false}
+            size="normal"
+          >
+            <p
+              className="LocationSelector__mainTextInput LocationSelector__mainTextInput--muted"
+            >
+              inputPlaceholder
+            </p>
+          </Text>
         </div>
-      </Autosuggest>
-    </LocationAutocomplete>
-    <Button
-      className="LocationSelector__button"
-      context="brand"
-      disabled={false}
-      href={null}
-      isBlock={false}
-      isInline={false}
-      onClick={[MockFunction]}
-      size="normal"
-      type="button"
-    >
-      <button
-        className="Button Button--context_brand LocationSelector__button"
-        disabled={false}
-        onClick={[MockFunction]}
-        type="button"
-      >
-        doneLabel
-      </button>
-    </Button>
-  </div>
-  <div
-    className="LocationSelector__locationsWrapper"
-  >
-    <ul
-      className="LocationSelector__locationCardsContainer"
-    >
-      <LocationCard
-        As="li"
-        className="LocationSelector__locationCard"
-        distanceRadius={42}
-        key="ajdo-219a-j19v-0491"
-        locationId="ajdo-219a-j19v-0491"
-        locationTitle="Amsterdam"
-        maxRadius={100}
-        minRadius={1}
-        onDelete={[MockFunction]}
-        onRadiusChange={[MockFunction]}
-        radiusStep={1}
-        sliderLabel="+ 42 km"
-      >
-        <li
-          className="LocationCard LocationSelector__locationCard"
+        <Button
+          className="FieldWrapper__clearButton"
+          context="link"
+          disabled={false}
+          href={null}
+          isBlock={false}
+          isInline={true}
+          onClick={[Function]}
+          size="normal"
+          type="button"
         >
-          <div
-            className="LocationCard__header"
+          <button
+            className="Button Button--context_link Button--isInline FieldWrapper__clearButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
           >
-            <Text
-              className="LocationCard__title"
-              context="default"
-              inline={false}
-              size="large"
-              title="Amsterdam"
-            >
-              <p
-                className="Text--size_large LocationCard__title"
-                title="Amsterdam"
-              >
-                Amsterdam
-              </p>
-            </Text>
-            <button
-              className="LocationCard__delete-button"
-              onClick={[Function]}
-              type="button"
-            >
-              ×
-            </button>
-          </div>
-          <div
-            className="LocationCard__slider"
-          >
-            <Slider
-              initialValue={0}
-              max={100}
-              min={1}
-              onChange={[Function]}
-              step={1}
-              value={42}
-            >
-              <ComponentEnhancer(undefined)
-                activeDotStyle={Object {}}
-                className=""
-                disabled={false}
-                dotStyle={Object {}}
-                dots={false}
-                handle={[Function]}
-                handleStyle={
-                  Array [
-                    Object {},
-                  ]
-                }
-                included={true}
-                initialValue={0}
-                marks={Object {}}
-                max={100}
-                min={1}
-                onAfterChange={[Function]}
-                onBeforeChange={[Function]}
-                onChange={[Function]}
-                prefixCls="rc-slider"
-                railStyle={Object {}}
-                step={1}
-                trackStyle={
-                  Array [
-                    Object {},
-                  ]
-                }
-                value={42}
-                vertical={false}
-              >
-                <div
-                  className="rc-slider"
-                  onBlur={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchStart={[Function]}
-                >
-                  <div
-                    className="rc-slider-rail"
-                    style={Object {}}
-                  />
-                  <Track
-                    className="rc-slider-track"
-                    included={true}
-                    length={41.41414141414141}
-                    offset={0}
-                    style={Object {}}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-track"
-                      style={
-                        Object {
-                          "left": "0%",
-                          "width": "41.41414141414141%",
-                        }
-                      }
-                    />
-                  </Track>
-                  <Steps
-                    activeDotStyle={Object {}}
-                    dotStyle={Object {}}
-                    dots={false}
-                    included={true}
-                    lowerBound={1}
-                    marks={Object {}}
-                    max={100}
-                    min={1}
-                    prefixCls="rc-slider"
-                    step={1}
-                    upperBound={42}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-step"
-                    />
-                  </Steps>
-                  <Handle
-                    className="rc-slider-handle"
-                    disabled={false}
-                    key="0"
-                    max={100}
-                    min={1}
-                    offset={41.41414141414141}
-                    prefixCls="rc-slider"
-                    style={Object {}}
-                    value={42}
-                    vertical={false}
-                  >
-                    <div
-                      aria-disabled={false}
-                      aria-valuemax={100}
-                      aria-valuemin={1}
-                      aria-valuenow={42}
-                      className="rc-slider-handle"
-                      onBlur={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      role="slider"
-                      style={
-                        Object {
-                          "left": "41.41414141414141%",
-                        }
-                      }
-                      tabIndex={0}
-                    />
-                  </Handle>
-                  <Marks
-                    className="rc-slider-mark"
-                    included={true}
-                    lowerBound={1}
-                    marks={Object {}}
-                    max={100}
-                    min={1}
-                    onClickLabel={[Function]}
-                    upperBound={42}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-mark"
-                    />
-                  </Marks>
-                </div>
-              </ComponentEnhancer(undefined)>
-            </Slider>
-            <Text
-              className="LocationCard__slider-label"
-              context="default"
-              inline={false}
-              size="small"
-            >
-              <p
-                className="Text--size_small LocationCard__slider-label"
-              >
-                + 42 km
-              </p>
-            </Text>
-          </div>
-        </li>
-      </LocationCard>
-      <LocationCard
-        As="li"
-        className="LocationSelector__locationCard"
-        distanceRadius={20}
-        key="ajdo-219a-j19v-0492"
-        locationId="ajdo-219a-j19v-0492"
-        locationTitle="Utrecht"
-        maxRadius={100}
-        minRadius={1}
-        onDelete={[MockFunction]}
-        onRadiusChange={[MockFunction]}
-        radiusStep={1}
-        sliderLabel="+ 20 km"
-      >
-        <li
-          className="LocationCard LocationSelector__locationCard"
-        >
-          <div
-            className="LocationCard__header"
-          >
-            <Text
-              className="LocationCard__title"
-              context="default"
-              inline={false}
-              size="large"
-              title="Utrecht"
-            >
-              <p
-                className="Text--size_large LocationCard__title"
-                title="Utrecht"
-              >
-                Utrecht
-              </p>
-            </Text>
-            <button
-              className="LocationCard__delete-button"
-              onClick={[Function]}
-              type="button"
-            >
-              ×
-            </button>
-          </div>
-          <div
-            className="LocationCard__slider"
-          >
-            <Slider
-              initialValue={0}
-              max={100}
-              min={1}
-              onChange={[Function]}
-              step={1}
-              value={20}
-            >
-              <ComponentEnhancer(undefined)
-                activeDotStyle={Object {}}
-                className=""
-                disabled={false}
-                dotStyle={Object {}}
-                dots={false}
-                handle={[Function]}
-                handleStyle={
-                  Array [
-                    Object {},
-                  ]
-                }
-                included={true}
-                initialValue={0}
-                marks={Object {}}
-                max={100}
-                min={1}
-                onAfterChange={[Function]}
-                onBeforeChange={[Function]}
-                onChange={[Function]}
-                prefixCls="rc-slider"
-                railStyle={Object {}}
-                step={1}
-                trackStyle={
-                  Array [
-                    Object {},
-                  ]
-                }
-                value={20}
-                vertical={false}
-              >
-                <div
-                  className="rc-slider"
-                  onBlur={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchStart={[Function]}
-                >
-                  <div
-                    className="rc-slider-rail"
-                    style={Object {}}
-                  />
-                  <Track
-                    className="rc-slider-track"
-                    included={true}
-                    length={19.19191919191919}
-                    offset={0}
-                    style={Object {}}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-track"
-                      style={
-                        Object {
-                          "left": "0%",
-                          "width": "19.19191919191919%",
-                        }
-                      }
-                    />
-                  </Track>
-                  <Steps
-                    activeDotStyle={Object {}}
-                    dotStyle={Object {}}
-                    dots={false}
-                    included={true}
-                    lowerBound={1}
-                    marks={Object {}}
-                    max={100}
-                    min={1}
-                    prefixCls="rc-slider"
-                    step={1}
-                    upperBound={20}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-step"
-                    />
-                  </Steps>
-                  <Handle
-                    className="rc-slider-handle"
-                    disabled={false}
-                    key="0"
-                    max={100}
-                    min={1}
-                    offset={19.19191919191919}
-                    prefixCls="rc-slider"
-                    style={Object {}}
-                    value={20}
-                    vertical={false}
-                  >
-                    <div
-                      aria-disabled={false}
-                      aria-valuemax={100}
-                      aria-valuemin={1}
-                      aria-valuenow={20}
-                      className="rc-slider-handle"
-                      onBlur={[Function]}
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      role="slider"
-                      style={
-                        Object {
-                          "left": "19.19191919191919%",
-                        }
-                      }
-                      tabIndex={0}
-                    />
-                  </Handle>
-                  <Marks
-                    className="rc-slider-mark"
-                    included={true}
-                    lowerBound={1}
-                    marks={Object {}}
-                    max={100}
-                    min={1}
-                    onClickLabel={[Function]}
-                    upperBound={20}
-                    vertical={false}
-                  >
-                    <div
-                      className="rc-slider-mark"
-                    />
-                  </Marks>
-                </div>
-              </ComponentEnhancer(undefined)>
-            </Slider>
-            <Text
-              className="LocationCard__slider-label"
-              context="default"
-              inline={false}
-              size="small"
-            >
-              <p
-                className="Text--size_small LocationCard__slider-label"
-              >
-                + 20 km
-              </p>
-            </Text>
-          </div>
-        </li>
-      </LocationCard>
-    </ul>
-    <Map
-      defaultArea={
-        Object {
-          "address": "NL",
-        }
-      }
-      mapContainerStyle={
-        Object {
-          "height": "100%",
-          "width": "100%",
-        }
-      }
-      markers={Array []}
+            Clear
+          </button>
+        </Button>
+      </div>
+    </FieldWrapper>
+    <Modal
+      ariaHideApp={false}
+      className="LocationSelector__modal"
+      contentLabel="Location selection dialog"
+      isOpen={false}
+      onRequestClose={[Function]}
     >
-      <GoogleMap
-        mapContainerStyle={
+      <Modal
+        ariaHideApp={false}
+        bodyOpenClassName="ReactModal__Body--open"
+        className={
           Object {
-            "height": "100%",
-            "width": "100%",
+            "afterOpen": "Modal__content--entered",
+            "base": "Modal__content LocationSelector__modal",
+            "beforeClose": "Modal__content--exited",
           }
         }
-        onLoad={[Function]}
-        options={
+        closeTimeoutMS={300}
+        contentLabel="Location selection dialog"
+        isOpen={false}
+        onRequestClose={[Function]}
+        overlayClassName={
           Object {
-            "fullscreenControl": false,
-            "mapTypeControl": false,
-            "rotateControl": false,
-            "streetViewControl": false,
+            "afterOpen": "Modal__overlay--entered",
+            "base": "Modal__overlay",
+            "beforeClose": "Modal__overlay--exited",
           }
         }
+        parentSelector={[Function]}
+        portalClassName="LocationSelector__modal"
+        role="dialog"
+        shouldCloseOnEsc={true}
+        shouldCloseOnOverlayClick={true}
+        shouldFocusAfterRender={true}
+        shouldReturnFocusAfterClose={true}
       >
-        <div
-          style={
-            Object {
-              "height": "100%",
-              "width": "100%",
+        <Portal
+          containerInfo={
+            <div
+              class="LocationSelector__modal"
+            />
+          }
+        >
+          <ModalPortal
+            ariaHideApp={false}
+            bodyOpenClassName="ReactModal__Body--open"
+            className={
+              Object {
+                "afterOpen": "Modal__content--entered",
+                "base": "Modal__content LocationSelector__modal",
+                "beforeClose": "Modal__content--exited",
+              }
             }
-          }
-        />
-      </GoogleMap>
-    </Map>
+            closeTimeoutMS={300}
+            contentLabel="Location selection dialog"
+            defaultStyles={
+              Object {
+                "content": Object {
+                  "WebkitOverflowScrolling": "touch",
+                  "background": "#fff",
+                  "border": "1px solid #ccc",
+                  "borderRadius": "4px",
+                  "bottom": "40px",
+                  "left": "40px",
+                  "outline": "none",
+                  "overflow": "auto",
+                  "padding": "20px",
+                  "position": "absolute",
+                  "right": "40px",
+                  "top": "40px",
+                },
+                "overlay": Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.75)",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "fixed",
+                  "right": 0,
+                  "top": 0,
+                },
+              }
+            }
+            isOpen={false}
+            onRequestClose={[Function]}
+            overlayClassName={
+              Object {
+                "afterOpen": "Modal__overlay--entered",
+                "base": "Modal__overlay",
+                "beforeClose": "Modal__overlay--exited",
+              }
+            }
+            parentSelector={[Function]}
+            portalClassName="LocationSelector__modal"
+            role="dialog"
+            shouldCloseOnEsc={true}
+            shouldCloseOnOverlayClick={true}
+            shouldFocusAfterRender={true}
+            shouldReturnFocusAfterClose={true}
+            style={
+              Object {
+                "content": Object {},
+                "overlay": Object {},
+              }
+            }
+          />
+        </Portal>
+      </Modal>
+    </Modal>
   </div>
 </LocationSelector>
 `;

--- a/src/components/LocationSelector/index.js
+++ b/src/components/LocationSelector/index.js
@@ -1,4 +1,5 @@
-export { default as LocationSelector } from './LocationSelector/LocationSelector';
+export { default as LocationSelectorDialog } from './LocationSelectorDialog';
 export {
-    default as LocationSelectorWithGoogleLoader,
-} from './LocationSelectorWithGoogleLoader/LocationSelectorWithGoogleLoader';
+    default as LocationSelectorDialogWithGoogleLoader,
+} from './LocationSelectorDialogWithGoogleLoader';
+export { default as LocationSelector } from './LocationSelector';

--- a/src/index.js
+++ b/src/index.js
@@ -39,4 +39,8 @@ export {
     LocationAutocompleteWithGoogleLoader,
     LocationAutocomplete,
 } from './components/LocationAutocomplete';
-export { LocationSelectorWithGoogleLoader, LocationSelector } from './components/LocationSelector';
+export {
+    LocationSelectorDialog,
+    LocationSelectorDialogWithGoogleLoader,
+    LocationSelector,
+} from './components/LocationSelector';

--- a/stories/LocationSelector.js
+++ b/stories/LocationSelector.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { number, text, select, boolean, withKnobs } from '@storybook/addon-knobs';
-import { LocationSelectorWithGoogleLoader } from '@textkernel/oneui';
+import { LocationSelector } from '@textkernel/oneui';
 import ensureApiKey from './utils/ensureApiKey';
 import withStore from '../src/packages/storybook/withStore';
 
@@ -40,7 +40,7 @@ storiesOf('Organisms|LocationSelector', module)
         const apiKey = ensureApiKey();
 
         return (
-            <LocationSelectorWithGoogleLoader
+            <LocationSelector
                 apiKey={apiKey}
                 selectedLocations={selectedLocations}
                 country={text('country', 'NL')}
@@ -110,7 +110,7 @@ storiesOf('Organisms|LocationSelector', module)
         };
 
         return (
-            <LocationSelectorWithGoogleLoader
+            <LocationSelector
                 apiKey={apiKey}
                 selectedLocations={store.get('selectedLocations')}
                 country={text('country', 'NL')}


### PR DESCRIPTION
Story: [ONEUI-95](https://jira.textkernel.nl/browse/ONEUI-95)

BREAKING CHANGE: LocationSelector and related components has been renamed. For top level use LocationSelector (instead of LocationSelectorWithGoogleLoader which has been deprecated). For sub components see documentation. 