### PR TITLE
 feat(Callout): changed `<p>` to `<div>` for content element, removed `lineHeightStyle`

### DIFF
--- a/src/components/Callout/Callout.scss
+++ b/src/components/Callout/Callout.scss
@@ -4,19 +4,16 @@ $icon-size: 16px;
 
 .Callout {
     display: flex;
-    padding: 0 var(--spacing-5x);
-    align-items: center;
-
-    &__content {
-        padding-right: var(--spacing-5x);
-    }
+    padding: var(--spacing-5x);
+    align-items: flex-start;
 
     &__closeButton {
-        display: inline-block;
+        display: block;
         flex-shrink: 0;
-        height: $icon-size;
-        width: $icon-size;
+        height: var(--icon-size);
+        width: var(--icon-size);
         padding: 0;
+        padding-left: var(--spacing-5x);
         margin-left: auto;
         cursor: pointer;
         background-color: var(--transparent);

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -5,26 +5,21 @@ import { Context } from '../../constants';
 import styles from './Callout.scss';
 
 interface Props {
+    /** Content to be rendered inside the container */
+    children: NotEmptyReactNode;
     /** The Callout context (e.g. brand, primary, bad, good etc. - defaults to info) */
     context?: Context;
-    /** A property specifies the height of a line. */
-    lineHeightStyle?: number;
-    /** Content to be rendered inside the container */
-    children: NotEmptySingleReactNode;
     /** A function to be called when close button was clicked */
-    onRequestClose?: (() => void) | null;
+    onRequestClose?: (event: React.SyntheticEvent<HTMLButtonElement>) => void;
 }
 
 const { block, elem } = bem('Callout', styles);
 
 const Callout: React.FC<Props> = props => {
-    const { onRequestClose, lineHeightStyle, children, ...rest } = props;
-
+    const { onRequestClose, children, context, ...rest } = props;
     return (
         <div {...rest} {...block(props)}>
-            <p {...elem('content', props)} style={{ lineHeight: `${lineHeightStyle}px` }}>
-                {children}
-            </p>
+            <div {...elem('content', props)}>{children}</div>
             {onRequestClose && (
                 <button {...elem('closeButton', props)} type="button" onClick={onRequestClose}>
                     <MdClose {...elem('closeIcon', props)} />
@@ -36,8 +31,6 @@ const Callout: React.FC<Props> = props => {
 
 Callout.defaultProps = {
     context: 'info',
-    onRequestClose: null,
-    lineHeightStyle: 22,
 };
 
 Callout.displayName = 'Callout';

--- a/src/components/Callout/__tests__/__snapshots__/Callout.spec.js.snap
+++ b/src/components/Callout/__tests__/__snapshots__/Callout.spec.js.snap
@@ -3,17 +3,11 @@
 exports[`Callout should render correctly 1`] = `
 <div
   className="Callout Callout--context_info"
-  context="info"
 >
-  <p
-    className="Callout__content Callout__content--context_info"
-    style={
-      Object {
-        "lineHeight": "22px",
-      }
-    }
+  <div
+    className="Callout__content--context_info"
   >
     some text
-  </p>
+  </div>
 </div>
 `;

--- a/stories/Callout.tsx
+++ b/stories/Callout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, number, select } from '@storybook/addon-knobs';
+import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { Callout } from '@textkernel/oneui';
 import { CONTEXTS } from '../src/constants';
 
@@ -11,15 +11,41 @@ storiesOf('Atoms|Callout', module)
             console.log('Callout was requested to be closed.');
         };
         return (
-            <Callout
-                context={select('Context', CONTEXTS, CONTEXTS[0])}
-                lineHeightStyle={number('Height of a line', 22)}
-                onRequestClose={onClose}
-            >
+            <Callout context={select('Context', CONTEXTS, CONTEXTS[0])} onRequestClose={onClose}>
                 {text(
                     'Content',
-                    `Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book`
+                    `Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book`
                 )}
+            </Callout>
+        );
+    })
+    .add('Callout with more content', () => {
+        const onClose = () => {
+            console.log('Callout was requested to be closed.');
+        };
+        return (
+            <Callout context={select('Context', CONTEXTS, CONTEXTS[7])} onRequestClose={onClose}>
+                <h2 style={{ margin: 0 }}>Request failed</h2>
+                <p>
+                    Lorem Ipsum has been the industry standard dummy text ever since the 1500s,
+                    unknown printer took a galley of type and scrambled it to make a type specimen
+                    specimen book.
+                </p>
+                <p>
+                    Lorem Ipsum has been the industry standard dummy text ever since the 1500s,
+                    unknown printer took a galley of type and scrambled it to make a type specimen
+                    Lorem Ipsum has been the industry standard dummy text ever since the 1500s,
+                    unknown printer took a galley of type and scrambled it to make a type specimen
+                    specimen book.
+                </p>
+                <p>
+                    Lorem Ipsum has been the industry standard dummy text ever since the 1500s,
+                    unknown printer took a galley of type and scrambled it to make a type specimen
+                    Lorem Ipsum has been the industry standard dummy text ever since the 1500s,
+                    unknown printer took a galley of type and scrambled it to make a type specimen
+                    Lorem Ipsum has been the industry standard dummy text ever since the 1500s,
+                    unknown printer took a galley of type and scrambled it to make a type book.
+                </p>
             </Callout>
         );
     });


### PR DESCRIPTION
    * `<div>` allows to render block-level HTML elements as Callout's children;
    * BREAKING CHANGE: `lineHeightStyle` removed. This property was
      redundant. Styling must be handled by passing a className.