### PR TITLE
fix(Footer): add year prop to Footer component to make it determenistic

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -7,18 +7,21 @@ import { LogoTextkernel } from '../Icon';
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
     /** supply copyright text ready to be rendered instead of the default one */
     copyright?: ReactNode;
+    /** Current year to be rendered as a part of copyright note */
+    year?: number;
     /** Node(s) to be rendered on the right side of the header */
     children?: ReactNode;
 }
 
+const currentYear = new Date().getFullYear();
 const { block, elem } = bem('Footer', styles);
 
 export const Footer: React.FC<Props> = (props) => {
-    const { copyright, children, ...rest } = props;
+    const { copyright, year = currentYear, children, ...rest } = props;
 
     const tkCopyright = (
         <span>
-            {`\u00a9 ${new Date().getFullYear()} `}
+            {year && `\u00a9 ${year} `}
             <LogoTextkernel {...elem('logo', props)} margin="left" />
         </span>
     );

--- a/src/components/Footer/__tests__/Footer.spec.js
+++ b/src/components/Footer/__tests__/Footer.spec.js
@@ -4,7 +4,7 @@ import { Footer } from '../Footer';
 
 describe('Footer component that renders a copyright text on the left and optional children on the right side', () => {
     it('should render correctly with TK copyright', () => {
-        const wrapper = mount(<Footer>This is a placeholder for children</Footer>);
+        const wrapper = mount(<Footer year={2019}>This is a placeholder for children</Footer>);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
     it('should render correctly with custom copyright', () => {

--- a/src/components/Footer/__tests__/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.spec.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Footer component that renders a copyright text on the left and optional children on the right side should render correctly with TK copyright 1`] = `
-<Footer>
+<Footer
+  year={2019}
+>
   <footer
     className="Footer"
   >

--- a/src/components/Footer/__tests__/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.spec.js.snap
@@ -15,7 +15,7 @@ exports[`Footer component that renders a copyright text on the left and optional
         className="BlockWidthRestrictor Footer__wrapper"
       >
         <span>
-          © 2022 
+          © 2019 
           <LogoTextkernel
             className="Footer__logo"
             margin="left"


### PR DESCRIPTION
Hardcoded `new Date().getFullYear();` caused test failure