### PR TITLE
fix(FieldWithValidation): change logic when using tooltip

### DIFF
--- a/src/components/FieldWithValidation/FieldWithValidation.tsx
+++ b/src/components/FieldWithValidation/FieldWithValidation.tsx
@@ -18,22 +18,20 @@ const { block } = bem('FieldWithValidation', styles);
 export const FieldWithValidation: React.FC<Props> = props => {
     const { children, errorMessage, useTooltip, ...rest } = props;
 
-    if (!errorMessage) {
-        return children;
-    }
-
-    const clonedChild = React.cloneElement(children, { context: 'bad' });
+    const clonedChild = errorMessage ? React.cloneElement(children, { context: 'bad' }) : children;
 
     return useTooltip ? (
-        <Tooltip {...rest} content={errorMessage}>
+        <Tooltip {...rest} content={errorMessage || ''}>
             {clonedChild}
         </Tooltip>
     ) : (
         <>
             {clonedChild}
-            <Text {...rest} {...block(props)} context="bad" size="small">
-                {errorMessage}
-            </Text>
+            {errorMessage && (
+                <Text {...rest} {...block(props)} context="bad" size="small">
+                    {errorMessage}
+                </Text>
+            )}
         </>
     );
 };

--- a/src/components/FieldWithValidation/FieldWithValidation.tsx
+++ b/src/components/FieldWithValidation/FieldWithValidation.tsx
@@ -21,7 +21,7 @@ export const FieldWithValidation: React.FC<Props> = props => {
     const clonedChild = errorMessage ? React.cloneElement(children, { context: 'bad' }) : children;
 
     return useTooltip ? (
-        <Tooltip {...rest} content={errorMessage || ''}>
+        <Tooltip {...rest} content={errorMessage}>
             {clonedChild}
         </Tooltip>
     ) : (

--- a/src/components/FieldWithValidation/FieldWithValidation.tsx
+++ b/src/components/FieldWithValidation/FieldWithValidation.tsx
@@ -17,23 +17,46 @@ const { block } = bem('FieldWithValidation', styles);
 
 export const FieldWithValidation: React.FC<Props> = props => {
     const { children, errorMessage, useTooltip, ...rest } = props;
+    const [isChildInFocus, setIsChildInFocus] = React.useState(false);
 
-    const clonedChild = errorMessage ? React.cloneElement(children, { context: 'bad' }) : children;
+    const handleFocus = () => {
+        setIsChildInFocus(true);
+    };
 
-    return useTooltip ? (
-        <Tooltip {...rest} content={errorMessage}>
-            {clonedChild}
-        </Tooltip>
-    ) : (
-        <>
-            {clonedChild}
-            {errorMessage && (
+    const handleBlur = () => {
+        setIsChildInFocus(false);
+    };
+
+    if (useTooltip) {
+        const clonedChild = errorMessage
+            ? React.cloneElement(children, {
+                  context: 'bad',
+                  onFocus: handleFocus,
+                  onBlur: handleBlur,
+              })
+            : children;
+
+        return (
+            <Tooltip {...rest} content={errorMessage} alwaysVisible={isChildInFocus}>
+                {clonedChild}
+            </Tooltip>
+        );
+    }
+
+    if (errorMessage) {
+        const clonedChild = React.cloneElement(children, { context: 'bad' });
+
+        return (
+            <>
+                {clonedChild}
                 <Text {...rest} {...block(props)} context="bad" size="small">
                     {errorMessage}
                 </Text>
-            )}
-        </>
-    );
+            </>
+        );
+    }
+
+    return children;
 };
 
 FieldWithValidation.defaultProps = {

--- a/src/components/FieldWithValidation/__tests__/FieldWithValidation.spec.js
+++ b/src/components/FieldWithValidation/__tests__/FieldWithValidation.spec.js
@@ -21,12 +21,12 @@ describe('FieldWithValidation', () => {
             expect(wrapper.find('Text')).toHaveLength(0);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
-        it('should simply render the child as it is, even if useTooltip is set to true', () => {
+        it('should render the tooltip, if useTooltip is set to true', () => {
             wrapper.setProps({ useTooltip: true });
             wrapper.update();
 
             expect(wrapper.find('Input')).toHaveLength(1);
-            expect(wrapper.find('Tooltip')).toHaveLength(0);
+            expect(wrapper.find('Tooltip')).toHaveLength(1);
             expect(wrapper.find('Text')).toHaveLength(0);
         });
     });

--- a/src/components/FieldWithValidation/__tests__/FieldWithValidation.spec.js
+++ b/src/components/FieldWithValidation/__tests__/FieldWithValidation.spec.js
@@ -6,55 +6,107 @@ import { Input } from '../../Input';
 describe('FieldWithValidation', () => {
     let wrapper;
 
-    describe('when error message is not defined', () => {
-        beforeEach(() => {
-            wrapper = mount(
-                <FieldWithValidation>
-                    <Input />
-                </FieldWithValidation>
-            );
-        });
+    describe('when rendering message as text', () => {
+        describe('with no error message passed', () => {
+            beforeEach(() => {
+                wrapper = mount(
+                    <FieldWithValidation>
+                        <Input />
+                    </FieldWithValidation>
+                );
+            });
 
-        it('should simply render the child as it is', () => {
-            expect(wrapper.find('Input')).toHaveLength(1);
-            expect(wrapper.find('Tooltip')).toHaveLength(0);
-            expect(wrapper.find('Text')).toHaveLength(0);
-            expect(toJson(wrapper)).toMatchSnapshot();
+            it('should simply render the child as it is', () => {
+                expect(wrapper.find('Input')).toHaveLength(1);
+                expect(wrapper.find('Tooltip')).toHaveLength(0);
+                expect(wrapper.find('Text')).toHaveLength(0);
+                expect(toJson(wrapper)).toMatchSnapshot();
+            });
         });
-        it('should render the tooltip, if useTooltip is set to true', () => {
-            wrapper.setProps({ useTooltip: true });
-            wrapper.update();
+        describe('with error message passed', () => {
+            const message = 'invalid field';
+            beforeEach(() => {
+                wrapper = mount(
+                    <FieldWithValidation errorMessage={message}>
+                        <Input />
+                    </FieldWithValidation>
+                );
+            });
 
-            expect(wrapper.find('Input')).toHaveLength(1);
-            expect(wrapper.find('Tooltip')).toHaveLength(1);
-            expect(wrapper.find('Text')).toHaveLength(0);
+            it('should set context to bad on child', () => {
+                expect(wrapper.find('Input').prop('context')).toBe('bad');
+            });
+            it('should render the message as text', () => {
+                expect(wrapper.find('Tooltip')).toHaveLength(0);
+                expect(wrapper.find('Text')).toHaveLength(1);
+                expect(wrapper.find('Text').text()).toBe(message);
+            });
         });
     });
-    describe('when error message is defined', () => {
-        const message = 'invalid field';
-        beforeEach(() => {
-            wrapper = mount(
-                <FieldWithValidation errorMessage={message}>
-                    <Input />
-                </FieldWithValidation>
-            );
-        });
+    describe('when using tooltip', () => {
+        describe('with no error message passed', () => {
+            beforeEach(() => {
+                wrapper = mount(
+                    <FieldWithValidation useTooltip>
+                        <Input />
+                    </FieldWithValidation>
+                );
+            });
 
-        it('should set context to bad on child', () => {
-            expect(wrapper.find('Input').prop('context')).toBe('bad');
-        });
-        it('should render the message as text', () => {
-            expect(wrapper.find('Tooltip')).toHaveLength(0);
-            expect(wrapper.find('Text')).toHaveLength(1);
-            expect(wrapper.find('Text').text()).toBe(message);
-        });
-        it('should render the message as tooltip when useTooltip is set to true', () => {
-            wrapper.setProps({ useTooltip: true });
-            wrapper.update();
+            it('should render the tooltip, but without content', () => {
+                wrapper.update();
 
-            expect(wrapper.find('Text')).toHaveLength(0);
-            expect(wrapper.find('Tooltip')).toHaveLength(1);
-            expect(wrapper.find('Tooltip').prop('content')).toBe(message);
+                expect(wrapper.find('Input')).toHaveLength(1);
+                expect(wrapper.find('Tooltip')).toHaveLength(1);
+                expect(wrapper.find('Text')).toHaveLength(0);
+
+                wrapper.find('input').simulate('mouseover');
+                expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
+            });
+        });
+        describe('when error message is defined', () => {
+            const message = 'invalid field';
+            beforeEach(() => {
+                wrapper = mount(
+                    <FieldWithValidation errorMessage={message} useTooltip>
+                        <Input />
+                    </FieldWithValidation>
+                );
+            });
+
+            it('should set context to bad on child', () => {
+                expect(wrapper.find('Input').prop('context')).toBe('bad');
+            });
+            it('should render the message on mouse over', () => {
+                expect(wrapper.find('Text')).toHaveLength(0);
+                expect(wrapper.find('Tooltip')).toHaveLength(1);
+                expect(wrapper.find('Tooltip').prop('content')).toBe(message);
+
+                wrapper.find('input').simulate('mouseover');
+                expect(wrapper.find('div[data-popup="true"]')).toHaveLength(1);
+                expect(wrapper.find('div[data-popup="true"]').text()).toBe(message);
+            });
+            it('should remove the message on mouse leave', () => {
+                wrapper.find('input').simulate('mouseover');
+                expect(wrapper.find('div[data-popup="true"]').text()).toBe(message);
+
+                wrapper.find('input').simulate('mouseleave');
+                expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
+            });
+            it('should render the message when field is focused', () => {
+                expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
+
+                wrapper.find('input').simulate('focus');
+                expect(wrapper.find('div[data-popup="true"]')).toHaveLength(1);
+                expect(wrapper.find('div[data-popup="true"]').text()).toBe(message);
+            });
+            it('should remove the message when field is blurred', () => {
+                wrapper.find('input').simulate('focus');
+                expect(wrapper.find('div[data-popup="true"]').text()).toBe(message);
+
+                wrapper.find('input').simulate('blur');
+                expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
+            });
         });
     });
 });

--- a/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.js.snap
+++ b/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FieldWithValidation when error message is not defined should simply render the child as it is 1`] = `
+exports[`FieldWithValidation when rendering message as text with no error message passed should simply render the child as it is 1`] = `
 <FieldWithValidation
   useTooltip={false}
 >

--- a/src/components/PopupBase/PopupBase.js
+++ b/src/components/PopupBase/PopupBase.js
@@ -115,6 +115,10 @@ export class PopupBase extends React.Component {
         if (isOpen) {
             const { popupRenderer } = this.props;
             const popupElem = popupRenderer(this.getArgs());
+            if (!popupElem) {
+                return null;
+            }
+
             const popupElemWithProps = React.cloneElement(popupElem, {
                 ref: this.popupRef,
                 'data-popup': 'true',

--- a/src/components/PopupBase/__tests__/PopupBase.spec.js
+++ b/src/components/PopupBase/__tests__/PopupBase.spec.js
@@ -49,6 +49,17 @@ describe('<PopupBase> that adds basic anchor/popup functionality to rendered com
             expect(wrapper.find('Popover')).toHaveLength(1);
             expect(wrapper.find('Portal')).toHaveLength(1);
         });
+        it('should support no popup content from renderer', () => {
+            wrapper = mount(
+                <PopupBase anchorRenderer={anchorRendererMock} popupRenderer={() => null} />
+            );
+
+            // trigger setPopupVisibility(true) through our dummy component
+            wrapper.find('button').simulate('click');
+
+            expect(toJson(wrapper)).toMatchSnapshot();
+            expect(wrapper.find('Popover')).toHaveLength(0);
+        });
         it('should close popup when requested', () => {
             // trigger setPopupVisibility(true) through our dummy component
             const triggerButton = wrapper.find('button');

--- a/src/components/PopupBase/__tests__/__snapshots__/PopupBase.spec.js.snap
+++ b/src/components/PopupBase/__tests__/__snapshots__/PopupBase.spec.js.snap
@@ -197,3 +197,34 @@ exports[`<PopupBase> that adds basic anchor/popup functionality to rendered comp
   </Button>
 </PopupBase>
 `;
+
+exports[`<PopupBase> that adds basic anchor/popup functionality to rendered components rendering should support no popup content from renderer 1`] = `
+<PopupBase
+  anchorRef={null}
+  anchorRenderer={[Function]}
+  onClose={null}
+  placement="bottom-start"
+  popupRef={null}
+  popupRenderer={[Function]}
+  renderInPortal={false}
+>
+  <Button
+    context="neutral"
+    disabled={false}
+    isBlock={false}
+    isInline={false}
+    onClick={[Function]}
+    size="normal"
+    type="button"
+  >
+    <button
+      className="Button Button--context_neutral"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Toggle popup
+    </button>
+  </Button>
+</PopupBase>
+`;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -21,6 +21,14 @@ export const Tooltip: React.FC<Props> = props => {
     // eslint-disable-next-line react/prop-types
     const { placement, content, children, alwaysVisible, ...rest } = props;
 
+    let openCall: (isOpen: boolean) => void = () => null;
+
+    React.useEffect(() => {
+        if (alwaysVisible) {
+            openCall(!!content);
+        }
+    }, [content, alwaysVisible]);
+
     const createMouseOverHandler = setPopupVisibility => () => {
         setPopupVisibility(true);
     };
@@ -31,8 +39,8 @@ export const Tooltip: React.FC<Props> = props => {
 
     // eslint-disable-next-line react/display-name
     const renderAnchor = ({ setPopupVisibility }) => {
+        openCall = setPopupVisibility;
         if (alwaysVisible) {
-            setPopupVisibility(true);
             return React.isValidElement(children) ? children : <span>{children}</span>;
         }
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { PopupPlacement } from '../../constants';
 import { PopupBase } from '../PopupBase';
+import { TooltipAnchor } from './TooltipAnchor';
 import styles from './Tooltip.scss';
 import { bem } from '../../utils';
 
@@ -21,40 +22,16 @@ export const Tooltip: React.FC<Props> = props => {
     // eslint-disable-next-line react/prop-types
     const { placement, content, children, alwaysVisible, ...rest } = props;
 
-    let openCall: (isOpen: boolean) => void = () => null;
-
-    React.useEffect(() => {
-        if (alwaysVisible) {
-            openCall(!!content);
-        }
-    }, [content, alwaysVisible]);
-
-    const createMouseOverHandler = setPopupVisibility => () => {
-        setPopupVisibility(true);
-    };
-
-    const createMouseLeaveHandler = setPopupVisibility => () => {
-        setPopupVisibility(false);
-    };
-
     // eslint-disable-next-line react/display-name
-    const renderAnchor = ({ setPopupVisibility }) => {
-        openCall = setPopupVisibility;
-        if (alwaysVisible) {
-            return React.isValidElement(children) ? children : <span>{children}</span>;
-        }
-
-        const mouseEventHandlers = {
-            onMouseOver: createMouseOverHandler(setPopupVisibility),
-            onMouseLeave: createMouseLeaveHandler(setPopupVisibility),
-        };
-
-        if (React.isValidElement(children)) {
-            return React.cloneElement(children, mouseEventHandlers);
-        }
-
-        return <span {...mouseEventHandlers}>{children}</span>;
-    };
+    const renderAnchor = ({ setPopupVisibility }) => (
+        <TooltipAnchor
+            alwaysVisible={alwaysVisible}
+            hasTooltipContent={!!content}
+            setPopupVisibility={setPopupVisibility}
+        >
+            {children}
+        </TooltipAnchor>
+    );
 
     // eslint-disable-next-line react/display-name
     const renderPopup = () =>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -10,7 +10,7 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
     /** Anchor component */
     children: NotEmptySingleReactNode;
     /** Popup component */
-    content: NotEmptySingleReactNode;
+    content?: SingleReactNode;
     /** Placement of the popup dialog relative to anchor */
     placement?: PopupPlacement;
 }
@@ -42,14 +42,15 @@ export const Tooltip: React.FC<Props> = props => {
     };
 
     // eslint-disable-next-line react/display-name
-    const renderPopup = () => (
-        <div>
-            <div {...rest} {...block(props)}>
-                {content}
-                <div {...elem('arrow', props)} />
+    const renderPopup = () =>
+        content ? (
+            <div>
+                <div {...rest} {...block(props)}>
+                    {content}
+                    <div {...elem('arrow', props)} />
+                </div>
             </div>
-        </div>
-    );
+        ) : null;
 
     return (
         <PopupBase

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -13,11 +13,13 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
     content?: SingleReactNode;
     /** Placement of the popup dialog relative to anchor */
     placement?: PopupPlacement;
+    /** If set to true will show the tooltip regardless of mouse position. When false, will show only on hover */
+    alwaysVisible?: boolean;
 }
 
 export const Tooltip: React.FC<Props> = props => {
     // eslint-disable-next-line react/prop-types
-    const { placement, content, children, ...rest } = props;
+    const { placement, content, children, alwaysVisible, ...rest } = props;
 
     const createMouseOverHandler = setPopupVisibility => () => {
         setPopupVisibility(true);
@@ -29,6 +31,11 @@ export const Tooltip: React.FC<Props> = props => {
 
     // eslint-disable-next-line react/display-name
     const renderAnchor = ({ setPopupVisibility }) => {
+        if (alwaysVisible) {
+            setPopupVisibility(true);
+            return React.isValidElement(children) ? children : <span>{children}</span>;
+        }
+
         const mouseEventHandlers = {
             onMouseOver: createMouseOverHandler(setPopupVisibility),
             onMouseLeave: createMouseLeaveHandler(setPopupVisibility),
@@ -65,4 +72,5 @@ Tooltip.displayName = 'Tooltip';
 
 Tooltip.defaultProps = {
     placement: 'bottom',
+    alwaysVisible: false,
 };

--- a/src/components/Tooltip/TooltipAnchor.tsx
+++ b/src/components/Tooltip/TooltipAnchor.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { usePrevious } from '../../hooks';
 
 interface Props extends React.HTMLAttributes<HTMLElement> {
     /** Anchor component */
@@ -16,13 +17,16 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
 export const TooltipAnchor: React.FC<Props> = React.forwardRef((props, ref) => {
     // eslint-disable-next-line react/prop-types
     const { hasTooltipContent, children, alwaysVisible, setPopupVisibility } = props;
+    const prevAlwaysVisible = usePrevious(alwaysVisible);
 
     /** Behavior related to tooltip that is always open */
     React.useEffect(() => {
         if (alwaysVisible) {
             setPopupVisibility(hasTooltipContent);
+        } else if (prevAlwaysVisible) {
+            setPopupVisibility(false);
         }
-    }, [hasTooltipContent, alwaysVisible]);
+    }, [hasTooltipContent, alwaysVisible, prevAlwaysVisible, setPopupVisibility]);
 
     if (alwaysVisible) {
         return React.isValidElement(children) ? (

--- a/src/components/Tooltip/TooltipAnchor.tsx
+++ b/src/components/Tooltip/TooltipAnchor.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+
+interface Props extends React.HTMLAttributes<HTMLElement> {
+    /** Anchor component */
+    children: NotEmptySingleReactNode;
+    /** indicates if there is a tooltip content or not */
+    hasTooltipContent: boolean;
+    /** If set to true will show the tooltip regardless of mouse position. When false, will show only on hover */
+    alwaysVisible?: boolean;
+    /** a function that toggles the visibility state of the tooltip */
+    setPopupVisibility: (isOpen: boolean) => void;
+    /** ref */
+    ref?: React.RefObject<HTMLElement>;
+}
+
+export const TooltipAnchor: React.FC<Props> = React.forwardRef((props, ref) => {
+    // eslint-disable-next-line react/prop-types
+    const { hasTooltipContent, children, alwaysVisible, setPopupVisibility } = props;
+
+    /** Behavior related to tooltip that is always open */
+    React.useEffect(() => {
+        if (alwaysVisible) {
+            setPopupVisibility(hasTooltipContent);
+        }
+    }, [hasTooltipContent, alwaysVisible]);
+
+    if (alwaysVisible) {
+        return React.isValidElement(children) ? (
+            React.cloneElement(children, { ref })
+        ) : (
+            <span ref={ref}>{children}</span>
+        );
+    }
+
+    /** Behavior related to tooltip that opens on hover only */
+    const mouseOverHandler = () => {
+        setPopupVisibility(true);
+    };
+
+    const mouseLeaveHandler = () => {
+        setPopupVisibility(false);
+    };
+
+    const extraProps = {
+        onMouseOver: mouseOverHandler,
+        onMouseLeave: mouseLeaveHandler,
+        ref,
+    };
+
+    if (React.isValidElement(children)) {
+        return React.cloneElement(children, extraProps);
+    }
+
+    return <span {...extraProps}>{children}</span>;
+});
+
+TooltipAnchor.displayName = 'TooltipAnchor';
+
+TooltipAnchor.defaultProps = {
+    alwaysVisible: false,
+    hasTooltipContent: false,
+};

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -104,5 +104,30 @@ describe('<Tooltip> that renders a Tooltip', () => {
             expect(visibilitySpy).toHaveBeenLastCalledWith(false);
             expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
         });
+        it('should remove / reopen tooltip if alwaysVisible prop changes', () => {
+            const wrapper = mount(
+                <Tooltip placement="bottom" content="content" alwaysVisible>
+                    I have a tooltip
+                </Tooltip>
+            );
+            expect(wrapper.find('div[data-popup="true"]')).toHaveLength(1);
+
+            // Since popper.js is mocked, we cannot see the popup properties such as placement in the wrapper
+            // instead we are going to spy on it to see if it was correctly opened/closed
+            const visibilitySpy = jest.spyOn(
+                wrapper.find('PopupBase').instance(),
+                'setPopupVisibility'
+            );
+
+            wrapper.setProps({ alwaysVisible: false });
+            wrapper.update();
+            expect(visibilitySpy).toHaveBeenLastCalledWith(false);
+            expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
+
+            wrapper.setProps({ alwaysVisible: true });
+            wrapper.update();
+            expect(visibilitySpy).toHaveBeenLastCalledWith(true);
+            expect(wrapper.find('div[data-popup="true"]')).toHaveLength(1);
+        });
     });
 });

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -22,6 +22,12 @@ describe('<Tooltip> that renders a Tooltip', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
         expect(wrapper.find('div[data-popup="true"]')).toHaveLength(1);
     });
+    it('should not display a tooltip on hover if there is no content defined', () => {
+        const wrapper = mount(<Tooltip placement="bottom">Hover me</Tooltip>);
+
+        wrapper.childAt(0).simulate('mouseover');
+        expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
+    });
     it('should display proper text inside a tooltip', () => {
         const tooltipText = 'Tooltip text';
         const wrapper = mount(

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -11,23 +11,6 @@ describe('<Tooltip> that renders a Tooltip', () => {
         );
         expect(toJson(wrapper)).toMatchSnapshot();
     });
-    it('should display a tooltip on hover', () => {
-        const wrapper = mount(
-            <Tooltip placement="bottom" content="content">
-                Hover me
-            </Tooltip>
-        );
-
-        wrapper.childAt(0).simulate('mouseover');
-        expect(toJson(wrapper)).toMatchSnapshot();
-        expect(wrapper.find('div[data-popup="true"]')).toHaveLength(1);
-    });
-    it('should not display a tooltip on hover if there is no content defined', () => {
-        const wrapper = mount(<Tooltip placement="bottom">Hover me</Tooltip>);
-
-        wrapper.childAt(0).simulate('mouseover');
-        expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
-    });
     it('should display proper text inside a tooltip', () => {
         const tooltipText = 'Tooltip text';
         const wrapper = mount(
@@ -44,15 +27,55 @@ describe('<Tooltip> that renders a Tooltip', () => {
                 .text()
         ).toEqual(tooltipText);
     });
-    it('should hide a tooltip on mouse leave', () => {
-        const wrapper = mount(
-            <Tooltip placement="bottom" content="content">
-                Hover me
-            </Tooltip>
-        );
+    it('should not display a tooltip if there is no content defined', () => {
+        const wrapper = mount(<Tooltip placement="bottom">Hover me</Tooltip>);
 
         wrapper.childAt(0).simulate('mouseover');
-        wrapper.childAt(0).simulate('mouseleave');
         expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
+    });
+    describe('tooltip on hover', () => {
+        it('should display a tooltip on hover', () => {
+            const wrapper = mount(
+                <Tooltip placement="bottom" content="content">
+                    Hover me
+                </Tooltip>
+            );
+
+            wrapper.childAt(0).simulate('mouseover');
+            expect(toJson(wrapper)).toMatchSnapshot();
+            expect(wrapper.find('div[data-popup="true"]')).toHaveLength(1);
+        });
+
+        it('should hide a tooltip on mouse leave', () => {
+            const wrapper = mount(
+                <Tooltip placement="bottom" content="content">
+                    Hover me
+                </Tooltip>
+            );
+
+            wrapper.childAt(0).simulate('mouseover');
+            wrapper.childAt(0).simulate('mouseleave');
+            expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
+        });
+    });
+    describe('always visible tooltip', () => {
+        it('should show the tooltip over simple text', () => {
+            const wrapper = mount(
+                <Tooltip placement="bottom" content="content" alwaysVisible>
+                    I have a tooltip
+                </Tooltip>
+            );
+
+            expect(wrapper.find('div[data-popup="true"]')).toHaveLength(1);
+        });
+        it('should show the tooltip over complex element', () => {
+            const wrapper = mount(
+                <Tooltip placement="bottom" content="content" alwaysVisible>
+                    <p>I have a tooltip</p>
+                </Tooltip>
+            );
+
+            expect(wrapper.find('div[data-popup="true"]')).toHaveLength(1);
+        });
     });
 });

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -53,8 +53,10 @@ describe('<Tooltip> that renders a Tooltip', () => {
                 </Tooltip>
             );
 
-            wrapper.childAt(0).simulate('mouseover');
-            wrapper.childAt(0).simulate('mouseleave');
+            wrapper
+                .childAt(0)
+                .simulate('mouseover')
+                .simulate('mouseleave');
             expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
         });
     });

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import toJson from 'enzyme-to-json';
-import { PopupBase } from '../../PopupBase';
 import { Tooltip } from '../Tooltip';
 
 describe('<Tooltip> that renders a Tooltip', () => {

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import toJson from 'enzyme-to-json';
+import { PopupBase } from '../../PopupBase';
 import { Tooltip } from '../Tooltip';
 
 describe('<Tooltip> that renders a Tooltip', () => {
@@ -76,6 +77,31 @@ describe('<Tooltip> that renders a Tooltip', () => {
             );
 
             expect(wrapper.find('div[data-popup="true"]')).toHaveLength(1);
+        });
+        it('should correctly open and close the tooltip if content changes', () => {
+            const wrapper = mount(
+                <Tooltip placement="bottom" alwaysVisible>
+                    I have a tooltip
+                </Tooltip>
+            );
+            expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
+
+            // Since popper.js is mocked, we cannot see the popup properties such as placement in the wrapper
+            // instead we are going to spy on it to see if it was correctly opened/closed
+            const visibilitySpy = jest.spyOn(
+                wrapper.find('PopupBase').instance(),
+                'setPopupVisibility'
+            );
+
+            wrapper.setProps({ content: 'content' });
+            wrapper.update();
+            expect(visibilitySpy).toHaveBeenLastCalledWith(true);
+            expect(wrapper.find('div[data-popup="true"]')).toHaveLength(1);
+
+            wrapper.setProps({ content: undefined });
+            wrapper.update();
+            expect(visibilitySpy).toHaveBeenLastCalledWith(false);
+            expect(wrapper.find('div[data-popup="true"]')).toHaveLength(0);
         });
     });
 });

--- a/src/components/Tooltip/__tests__/__snapshots__/Tooltip.spec.js.snap
+++ b/src/components/Tooltip/__tests__/__snapshots__/Tooltip.spec.js.snap
@@ -15,12 +15,18 @@ exports[`<Tooltip> that renders a Tooltip should render default Tooltip correctl
     popupRenderer={[Function]}
     renderInPortal={false}
   >
-    <span
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
+    <TooltipAnchor
+      alwaysVisible={false}
+      hasTooltipContent={true}
+      setPopupVisibility={[Function]}
     >
-      Hover me
-    </span>
+      <span
+        onMouseLeave={[Function]}
+        onMouseOver={[Function]}
+      >
+        Hover me
+      </span>
+    </TooltipAnchor>
   </PopupBase>
 </Tooltip>
 `;
@@ -40,12 +46,18 @@ exports[`<Tooltip> that renders a Tooltip tooltip on hover should display a tool
     popupRenderer={[Function]}
     renderInPortal={false}
   >
-    <span
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
+    <TooltipAnchor
+      alwaysVisible={false}
+      hasTooltipContent={true}
+      setPopupVisibility={[Function]}
     >
-      Hover me
-    </span>
+      <span
+        onMouseLeave={[Function]}
+        onMouseOver={[Function]}
+      >
+        Hover me
+      </span>
+    </TooltipAnchor>
     <div
       data-popup="true"
     >

--- a/src/components/Tooltip/__tests__/__snapshots__/Tooltip.spec.js.snap
+++ b/src/components/Tooltip/__tests__/__snapshots__/Tooltip.spec.js.snap
@@ -1,7 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tooltip> that renders a Tooltip should display a tooltip on hover 1`] = `
+exports[`<Tooltip> that renders a Tooltip should render default Tooltip correctly 1`] = `
 <Tooltip
+  alwaysVisible={false}
+  content="content"
+  placement="bottom"
+>
+  <PopupBase
+    anchorRef={null}
+    anchorRenderer={[Function]}
+    onClose={null}
+    placement="bottom"
+    popupRef={null}
+    popupRenderer={[Function]}
+    renderInPortal={false}
+  >
+    <span
+      onMouseLeave={[Function]}
+      onMouseOver={[Function]}
+    >
+      Hover me
+    </span>
+  </PopupBase>
+</Tooltip>
+`;
+
+exports[`<Tooltip> that renders a Tooltip tooltip on hover should display a tooltip on hover 1`] = `
+<Tooltip
+  alwaysVisible={false}
   content="content"
   placement="bottom"
 >
@@ -32,30 +58,6 @@ exports[`<Tooltip> that renders a Tooltip should display a tooltip on hover 1`] 
         />
       </div>
     </div>
-  </PopupBase>
-</Tooltip>
-`;
-
-exports[`<Tooltip> that renders a Tooltip should render default Tooltip correctly 1`] = `
-<Tooltip
-  content="content"
-  placement="bottom"
->
-  <PopupBase
-    anchorRef={null}
-    anchorRenderer={[Function]}
-    onClose={null}
-    placement="bottom"
-    popupRef={null}
-    popupRenderer={[Function]}
-    renderInPortal={false}
-  >
-    <span
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
-    >
-      Hover me
-    </span>
   </PopupBase>
 </Tooltip>
 `;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useDebounce } from './useDebounce';
+export { usePrevious } from './usePrevious';

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+// https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+export function usePrevious<T>(value: T) {
+    const ref = React.useRef<T>();
+    React.useEffect(() => {
+        ref.current = value;
+    });
+
+    return ref.current;
+}

--- a/stories/FieldWithValidation.tsx
+++ b/stories/FieldWithValidation.tsx
@@ -3,6 +3,34 @@ import { storiesOf } from '@storybook/react';
 import { text, boolean, withKnobs } from '@storybook/addon-knobs';
 import { FieldWithValidation, Input, TextArea } from '@textkernel/oneui';
 
+const Example = () => {
+    const [inputValue, setValue] = React.useState('');
+    const [errMsg, setErrMsg] = React.useState<string>();
+    const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+    React.useEffect(() => {
+        console.log(inputValue);
+        setErrMsg(inputValue.match(EMAIL_REGEX) ? undefined : 'This is not a valid email address');
+    }, [inputValue, EMAIL_REGEX]);
+
+    return (
+        <div style={{ marginBottom: '10px' }}>
+            <FieldWithValidation
+                errorMessage={errMsg}
+                useTooltip={boolean('Use tooltip for input field', false)}
+            >
+                <Input
+                    value={inputValue}
+                    onChange={e => {
+                        const { value } = e.target;
+                        setValue(value);
+                    }}
+                />
+            </FieldWithValidation>
+        </div>
+    );
+};
+
 storiesOf('Molecules|FieldWithValidation', module)
     .addDecorator(withKnobs)
     .add('FieldWithValidation', () => (
@@ -24,4 +52,5 @@ storiesOf('Molecules|FieldWithValidation', module)
                 </FieldWithValidation>
             </div>
         </>
-    ));
+    ))
+    .add('Example implementation', () => <Example />);

--- a/stories/FieldWithValidation.tsx
+++ b/stories/FieldWithValidation.tsx
@@ -6,11 +6,17 @@ import { FieldWithValidation, Input, TextArea } from '@textkernel/oneui';
 const Example = () => {
     const [inputValue, setValue] = React.useState('');
     const [errMsg, setErrMsg] = React.useState<string>();
-    const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+    // eslint-disable-next-line no-useless-escape
+    const EMAIL_REGEX = /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
 
     React.useEffect(() => {
-        console.log(inputValue);
-        setErrMsg(inputValue.match(EMAIL_REGEX) ? undefined : 'This is not a valid email address');
+        if (!inputValue) {
+            setErrMsg('This field is required');
+        } else {
+            setErrMsg(
+                inputValue.match(EMAIL_REGEX) ? undefined : 'This is not a valid email address'
+            );
+        }
     }, [inputValue, EMAIL_REGEX]);
 
     return (

--- a/stories/Tooltip.tsx
+++ b/stories/Tooltip.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, select, text } from '@storybook/addon-knobs';
+import { withKnobs, select, text, boolean } from '@storybook/addon-knobs';
 import { Tooltip } from '@textkernel/oneui';
 import { POPUP_PLACEMENTS } from '../src/constants';
 
@@ -11,6 +11,7 @@ storiesOf('Molecules|Tooltip', module)
             <Tooltip
                 placement={select('Placement', POPUP_PLACEMENTS, 'bottom')}
                 content={text('Tooltip text', 'this is my tooltip text')}
+                alwaysVisible={boolean('Always show tooltip', false)}
             >
                 hover here to see the tooltip
             </Tooltip>


### PR DESCRIPTION
Story: [ONEUI-146](https://jira.textkernel.nl/browse/ONEUI-146)

Changes to behaviour:
* always render tooltip in FieldWithValidation when `useTooltip` is set to true
* always show tooltip if underlying component is focused
* allow `null` as result of renderPopup() in PopupBase
* do not render tooltip popup if it has no content
* add 'always visible' option to Tooltip