### PR TITLE
feat(Select): make props clearer

### DIFF
--- a/src/components/Select/AutosuggestMulti/AutosuggestMulti.tsx
+++ b/src/components/Select/AutosuggestMulti/AutosuggestMulti.tsx
@@ -22,6 +22,8 @@ interface Props<S> extends CommonPropsWithClear<S> {
     numberOfVisibleTags?: number;
     /** to be shown in the input field when no value is typed */
     inputPlaceholder: string;
+    /** to be shown when no suggestions are available */
+    noSuggestionsPlaceholder?: string;
     /** Defines if the first item of suggestions list is always visible */
     isFirstItemAlwaysVisible?: boolean;
     /** Enable ListOptimizer component for decreasing render time */
@@ -44,6 +46,7 @@ export function AutosuggestMulti<S>(props: Props<S>) {
         suggestionToKey,
         suggestionItemRenderer,
         inputPlaceholder,
+        noSuggestionsPlaceholder,
         useOptimizeListRender,
         suggestions,
         isLoading,
@@ -175,6 +178,7 @@ export function AutosuggestMulti<S>(props: Props<S>) {
                     useOptimizeRender={useOptimizeListRender}
                     suggestionToKey={suggestionToKey}
                     suggestionItemRenderer={suggestionItemRenderer}
+                    noSuggestionsPlaceholder={noSuggestionsPlaceholder}
                 />
             )}
             focusedRenderer={renderFocused}
@@ -199,4 +203,5 @@ AutosuggestMulti.defaultProps = {
     useOptimizeListRender: false,
     onSubmit: null,
     onSelectionRemove: null,
+    noSuggestionsPlaceholder: '',
 };

--- a/src/components/Select/AutosuggestMulti/AutosuggestMulti.tsx
+++ b/src/components/Select/AutosuggestMulti/AutosuggestMulti.tsx
@@ -38,7 +38,7 @@ export function AutosuggestMulti<S>(props: Props<S>) {
     const {
         id,
         onInputValueChange,
-        onSelectionChange,
+        onSelectionAdd,
         selectedSuggestions = [],
         suggestionToString,
         suggestionToKey,
@@ -165,7 +165,7 @@ export function AutosuggestMulti<S>(props: Props<S>) {
             inputRef={inputRef}
             onFocus={onFocus}
             onBlur={onBlur}
-            onSelectionChange={onSelectionChange}
+            onSelectionAdd={onSelectionAdd}
             onInputValueChange={handleInputValueChange}
             listRenderer={(listProps) => (
                 <SuggestionsList

--- a/src/components/Select/AutosuggestMulti/AutosuggestMulti.tsx
+++ b/src/components/Select/AutosuggestMulti/AutosuggestMulti.tsx
@@ -12,25 +12,25 @@ import styles from './AutosuggestMulti.scss';
 import { BACKSPACE_KEY, ESCAPE_KEY, ENTER_KEY } from '../../../constants';
 
 interface Props<S> extends CommonPropsWithClear<S> {
-    /** define id for input element */
+    /** HTML id for the input element */
     id?: string;
-    /** makes a key to be used for a suggestion item */
+    /** Creates a unique (React) key for a suggestion item. If undefined suggestionToString will be used */
     suggestionToKey?: (suggestions: S) => string;
-    /** array of already selected suggestions */
+    /** An array of already selected suggestions */
     selectedSuggestions?: S[];
-    /** number of visible tags in blur mode */
+    /** Number of visible tags in blur mode */
     numberOfVisibleTags?: number;
-    /** to be shown in the input field when no value is typed */
+    /** String to be shown in the input field when no value is typed */
     inputPlaceholder: string;
-    /** to be shown when no suggestions are available */
+    /** String to be shown when no suggestions are available */
     noSuggestionsPlaceholder?: string;
-    /** Defines if the first item of suggestions list is always visible */
+    /** Defines if the first item of suggestions list is visible even while loading other elements */
     isFirstItemAlwaysVisible?: boolean;
     /** Enable ListOptimizer component for decreasing render time */
     useOptimizeListRender?: boolean;
-    /** onSelectionChange() called when a suggestion is removed  */
+    /** Function to be called when a suggestion is removed  */
     onSelectionRemove?: (item: S) => void;
-    /** function is called on submitting form */
+    /** Function to be called on submitting form */
     onSubmit?: () => void;
 }
 

--- a/src/components/Select/AutosuggestMulti/AutosuggestMulti.tsx
+++ b/src/components/Select/AutosuggestMulti/AutosuggestMulti.tsx
@@ -27,7 +27,7 @@ interface Props<S> extends CommonPropsWithClear<S> {
     /** Enable ListOptimizer component for decreasing render time */
     useOptimizeListRender?: boolean;
     /** onSelectionChange() called when a suggestion is removed  */
-    onSelectionRemove: (item: S) => void;
+    onSelectionRemove?: (item: S) => void;
     /** function is called on submitting form */
     onSubmit?: () => void;
 }
@@ -66,7 +66,7 @@ export function AutosuggestMulti<S>(props: Props<S>) {
 
     const renderFullTagsList = () => {
         return selectedSuggestions.map((item) => (
-            <SuggestionTag key={suggestionToString(item)} onClick={() => onSelectionRemove(item)}>
+            <SuggestionTag key={suggestionToString(item)} onClick={() => onSelectionRemove?.(item)}>
                 {suggestionToString(item)}
             </SuggestionTag>
         ));
@@ -114,7 +114,7 @@ export function AutosuggestMulti<S>(props: Props<S>) {
             inputRef.current?.blur();
         } else if (event.key === BACKSPACE_KEY && !inputValue && !!selectedSuggestions.length) {
             const lastItem = selectedSuggestions[selectedSuggestions.length - 1];
-            onSelectionRemove(lastItem);
+            onSelectionRemove?.(lastItem);
         }
     };
 
@@ -198,4 +198,5 @@ AutosuggestMulti.defaultProps = {
     isFirstItemAlwaysVisible: false,
     useOptimizeListRender: false,
     onSubmit: null,
+    onSelectionRemove: null,
 };

--- a/src/components/Select/AutosuggestMulti/__tests__/AutosuggestMulti.spec.js
+++ b/src/components/Select/AutosuggestMulti/__tests__/AutosuggestMulti.spec.js
@@ -7,7 +7,7 @@ describe('AutosuggestMulti', () => {
     const suggestionToString = SUGGESTION_TO_STRING;
     const inputPlaceholder = 'type here...';
     const numberOfVisibleTags = 3;
-    const mockOnSelectionChange = jest.fn();
+    const mockOnSelectionAdd = jest.fn();
     const mockOnSelectionRemove = jest.fn();
     const mockOnInputValueChange = jest.fn();
     const mockOnBlur = jest.fn();
@@ -26,7 +26,7 @@ describe('AutosuggestMulti', () => {
                 suggestions={suggestionsList}
                 suggestionToString={suggestionToString}
                 inputPlaceholder={inputPlaceholder}
-                onSelectionChange={mockOnSelectionChange}
+                onSelectionAdd={mockOnSelectionAdd}
                 onSelectionRemove={mockOnSelectionRemove}
                 onInputValueChange={mockOnInputValueChange}
                 numberOfVisibleTags={numberOfVisibleTags}
@@ -115,41 +115,41 @@ describe('AutosuggestMulti', () => {
         });
     });
     describe('callbacks', () => {
-        describe('onSelectionChange', () => {
+        describe('onSelectionAdd', () => {
             it('should be called on clicking on a suggestion', () => {
                 suggestionsList = SUGGESTIONS.slice(1, 20);
                 wrapper.setProps({ suggestions: suggestionsList });
                 setFocusOnInput();
 
-                expect(mockOnSelectionChange).not.toHaveBeenCalled();
+                expect(mockOnSelectionAdd).not.toHaveBeenCalled();
 
                 wrapper.find('input').simulate('change', { target: { value: 'a' } });
                 wrapper.find('li').first().children().simulate('click');
 
-                expect(mockOnSelectionChange).toHaveBeenCalled();
+                expect(mockOnSelectionAdd).toHaveBeenCalled();
             });
             it('should be called also when clicking on a suggestion the second time in a row', () => {
                 suggestionsList = SUGGESTIONS.slice(1, 20);
                 wrapper.setProps({ suggestions: suggestionsList });
                 setFocusOnInput();
 
-                expect(mockOnSelectionChange).not.toHaveBeenCalled();
+                expect(mockOnSelectionAdd).not.toHaveBeenCalled();
 
                 wrapper.find('li').first().children().simulate('click');
 
-                expect(mockOnSelectionChange).toHaveBeenCalledTimes(1);
+                expect(mockOnSelectionAdd).toHaveBeenCalledTimes(1);
 
                 setFocusOnInput();
                 wrapper.find('li').first().children().simulate('click');
 
-                expect(mockOnSelectionChange).toHaveBeenCalledTimes(2);
+                expect(mockOnSelectionAdd).toHaveBeenCalledTimes(2);
             });
             it('should be called on deleting a suggestion by clicking on the x button next to it', () => {
                 selectedSuggestions = SUGGESTIONS.slice(0, 5);
                 wrapper.setProps({ selectedSuggestions });
                 setFocusOnInput();
 
-                expect(mockOnSelectionChange).not.toHaveBeenCalled();
+                expect(mockOnSelectionAdd).not.toHaveBeenCalled();
                 expect(wrapper.find('SuggestionTag')).toHaveLength(selectedSuggestions.length);
 
                 wrapper.find('SuggestionTag').at(2).find('button').simulate('click');

--- a/src/components/Select/AutosuggestMulti/__tests__/__snapshots__/AutosuggestMulti.spec.js.snap
+++ b/src/components/Select/AutosuggestMulti/__tests__/__snapshots__/AutosuggestMulti.spec.js.snap
@@ -8,7 +8,7 @@ exports[`AutosuggestMulti rendering should initially render empty component corr
   numberOfVisibleTags={3}
   onBlur={[MockFunction]}
   onInputValueChange={[MockFunction]}
-  onSelectionChange={[MockFunction]}
+  onSelectionAdd={[MockFunction]}
   onSelectionRemove={[MockFunction]}
   onSubmit={null}
   selectedSuggestions={Array []}
@@ -40,7 +40,7 @@ exports[`AutosuggestMulti rendering should initially render empty component corr
     listRenderer={[Function]}
     onBlur={[MockFunction]}
     onInputValueChange={[Function]}
-    onSelectionChange={[MockFunction]}
+    onSelectionAdd={[MockFunction]}
     selectOnTab={true}
     showClearButton={false}
     suggestionToString={[Function]}
@@ -156,7 +156,7 @@ exports[`AutosuggestMulti rendering should render component with suggestions 1`]
       ],
     }
   }
-  onSelectionChange={[MockFunction]}
+  onSelectionAdd={[MockFunction]}
   onSelectionRemove={[MockFunction]}
   onSubmit={null}
   selectedSuggestions={Array []}
@@ -217,7 +217,7 @@ exports[`AutosuggestMulti rendering should render component with suggestions 1`]
     listRenderer={[Function]}
     onBlur={[MockFunction]}
     onInputValueChange={[Function]}
-    onSelectionChange={[MockFunction]}
+    onSelectionAdd={[MockFunction]}
     selectOnTab={true}
     showClearButton={false}
     suggestionToString={[Function]}
@@ -772,7 +772,7 @@ exports[`AutosuggestMulti rendering should render isLoading state 1`] = `
       ],
     }
   }
-  onSelectionChange={[MockFunction]}
+  onSelectionAdd={[MockFunction]}
   onSelectionRemove={[MockFunction]}
   onSubmit={null}
   selectedSuggestions={Array []}
@@ -806,7 +806,7 @@ exports[`AutosuggestMulti rendering should render isLoading state 1`] = `
     listRenderer={[Function]}
     onBlur={[MockFunction]}
     onInputValueChange={[Function]}
-    onSelectionChange={[MockFunction]}
+    onSelectionAdd={[MockFunction]}
     selectOnTab={true}
     showClearButton={false}
     suggestionToString={[Function]}

--- a/src/components/Select/AutosuggestMulti/__tests__/__snapshots__/AutosuggestMulti.spec.js.snap
+++ b/src/components/Select/AutosuggestMulti/__tests__/__snapshots__/AutosuggestMulti.spec.js.snap
@@ -5,6 +5,7 @@ exports[`AutosuggestMulti rendering should initially render empty component corr
   inputPlaceholder="type here..."
   isFirstItemAlwaysVisible={false}
   isLoading={false}
+  noSuggestionsPlaceholder=""
   numberOfVisibleTags={3}
   onBlur={[MockFunction]}
   onInputValueChange={[MockFunction]}
@@ -139,6 +140,7 @@ exports[`AutosuggestMulti rendering should render component with suggestions 1`]
   inputPlaceholder="type here..."
   isFirstItemAlwaysVisible={false}
   isLoading={false}
+  noSuggestionsPlaceholder=""
   numberOfVisibleTags={3}
   onBlur={[MockFunction]}
   onInputValueChange={
@@ -755,6 +757,7 @@ exports[`AutosuggestMulti rendering should render isLoading state 1`] = `
   inputPlaceholder="type here..."
   isFirstItemAlwaysVisible={false}
   isLoading={true}
+  noSuggestionsPlaceholder=""
   numberOfVisibleTags={3}
   onBlur={[MockFunction]}
   onInputValueChange={

--- a/src/components/Select/ComboboxMulti/ComboboxMulti.tsx
+++ b/src/components/Select/ComboboxMulti/ComboboxMulti.tsx
@@ -22,7 +22,7 @@ interface Props<S> extends CommonProps<S> {
 export function ComboboxMulti<S>(props: Props<S>) {
     const {
         id,
-        onSelectionChange,
+        onSelectionAdd,
         inputRef: inputRefFromProps,
         suggestions,
         suggestionToString,
@@ -96,7 +96,7 @@ export function ComboboxMulti<S>(props: Props<S>) {
             suggestionToString={suggestionToString}
             inputRef={inputRef}
             onBlur={onBlur}
-            onSelectionChange={onSelectionChange}
+            onSelectionAdd={onSelectionAdd}
             onInputValueChange={onInputValueChange}
             listRenderer={(listProps) => (
                 <SuggestionsList

--- a/src/components/Select/ComboboxMulti/__tests__/ComboboxMulti.spec.js
+++ b/src/components/Select/ComboboxMulti/__tests__/ComboboxMulti.spec.js
@@ -7,7 +7,7 @@ describe('ComboboxMulti', () => {
     const suggestionToString = SUGGESTION_TO_STRING;
     const inputPlaceholder = 'type here...';
     const noSuggestionsPlaceholder = 'No suggestions...';
-    const mockOnSelectionChange = jest.fn();
+    const mockOnSelectionAdd = jest.fn();
     const mockOnInputValueChange = jest.fn();
     const mockOnBlur = jest.fn();
 
@@ -25,7 +25,7 @@ describe('ComboboxMulti', () => {
                 suggestionToString={suggestionToString}
                 inputPlaceholder={inputPlaceholder}
                 noSuggestionsPlaceholder={noSuggestionsPlaceholder}
-                onSelectionChange={mockOnSelectionChange}
+                onSelectionAdd={mockOnSelectionAdd}
                 onInputValueChange={mockOnInputValueChange}
                 onBlur={mockOnBlur}
             />
@@ -124,15 +124,15 @@ describe('ComboboxMulti', () => {
         });
     });
     describe('callbacks', () => {
-        describe('onSelectionChange', () => {
+        describe('onSelectionAdd', () => {
             it('should be called on clicking on a suggestion', () => {
                 setFocusOnInput();
 
-                expect(mockOnSelectionChange).not.toHaveBeenCalled();
+                expect(mockOnSelectionAdd).not.toHaveBeenCalled();
 
                 wrapper.find('li').first().children().simulate('click');
 
-                expect(mockOnSelectionChange).toHaveBeenCalled();
+                expect(mockOnSelectionAdd).toHaveBeenCalled();
             });
         });
         it('should call onInputValueChange when typing into input field', () => {

--- a/src/components/Select/ComboboxMulti/__tests__/__snapshots__/ComboboxMulti.spec.js.snap
+++ b/src/components/Select/ComboboxMulti/__tests__/__snapshots__/ComboboxMulti.spec.js.snap
@@ -317,6 +317,7 @@ exports[`ComboboxMulti rendering should render all suggestions from the list 1`]
     onBlur={[MockFunction]}
     onInputValueChange={[MockFunction]}
     onSelectionAdd={[MockFunction]}
+    selectOnTab={false}
     showClearButton={false}
     suggestionToString={[Function]}
     suggestions={

--- a/src/components/Select/ComboboxMulti/__tests__/__snapshots__/ComboboxMulti.spec.js.snap
+++ b/src/components/Select/ComboboxMulti/__tests__/__snapshots__/ComboboxMulti.spec.js.snap
@@ -6,7 +6,7 @@ exports[`ComboboxMulti rendering should initially render empty component correct
   noSuggestionsPlaceholder="No suggestions..."
   onBlur={[MockFunction]}
   onInputValueChange={[MockFunction]}
-  onSelectionChange={[MockFunction]}
+  onSelectionAdd={[MockFunction]}
   suggestionToString={[Function]}
   suggestions={
     Array [
@@ -64,7 +64,7 @@ exports[`ComboboxMulti rendering should initially render empty component correct
     listRenderer={[Function]}
     onBlur={[MockFunction]}
     onInputValueChange={[MockFunction]}
-    onSelectionChange={[MockFunction]}
+    onSelectionAdd={[MockFunction]}
     selectOnTab={false}
     showClearButton={false}
     suggestionToString={[Function]}
@@ -256,7 +256,7 @@ exports[`ComboboxMulti rendering should render all suggestions from the list 1`]
   noSuggestionsPlaceholder="No suggestions..."
   onBlur={[MockFunction]}
   onInputValueChange={[MockFunction]}
-  onSelectionChange={[MockFunction]}
+  onSelectionAdd={[MockFunction]}
   suggestionToString={[Function]}
   suggestions={
     Array [
@@ -316,8 +316,7 @@ exports[`ComboboxMulti rendering should render all suggestions from the list 1`]
     listRenderer={[Function]}
     onBlur={[MockFunction]}
     onInputValueChange={[MockFunction]}
-    onSelectionChange={[MockFunction]}
-    selectOnTab={false}
+    onSelectionAdd={[MockFunction]}
     showClearButton={false}
     suggestionToString={[Function]}
     suggestions={

--- a/src/components/Select/SelectBase/SelectBase.tsx
+++ b/src/components/Select/SelectBase/SelectBase.tsx
@@ -18,7 +18,7 @@ export function SelectBase<S>(props: Props<S>) {
         selectOnTab,
         onFocus,
         onBlur,
-        onSelectionChange,
+        onSelectionAdd,
         onInputValueChange,
         onClearAllSelected,
         inputRef: inputRefFromProps,
@@ -92,7 +92,7 @@ export function SelectBase<S>(props: Props<S>) {
         clearSelection();
 
         if (selectedItem) {
-            onSelectionChange(selectedItem);
+            onSelectionAdd(selectedItem);
         }
 
         if (clearInputAfterSelection) {

--- a/src/components/Select/SelectBase/__tests__/SelectBase.spec.js
+++ b/src/components/Select/SelectBase/__tests__/SelectBase.spec.js
@@ -8,7 +8,7 @@ describe('SelectBase', () => {
     const inputRef = React.createRef();
     const suggestions = SUGGESTIONS;
     const suggestionToString = SUGGESTION_TO_STRING;
-    const mockOnSelectionChange = jest.fn();
+    const mockOnSelectionAdd = jest.fn();
     const mockOnInputValueChange = jest.fn();
     const mockOnClearAllSelected = jest.fn();
     const mockOnBlur = jest.fn();
@@ -30,7 +30,7 @@ describe('SelectBase', () => {
                 listRenderer={(listProps) => <SuggestionsList {...listProps} />}
                 focusedRenderer={mockRender}
                 blurredRenderer={mockRender}
-                onSelectionChange={mockOnSelectionChange}
+                onSelectionAdd={mockOnSelectionAdd}
                 onInputValueChange={mockOnInputValueChange}
                 onClearAllSelected={mockOnClearAllSelected}
                 onBlur={mockOnBlur}
@@ -124,15 +124,15 @@ describe('SelectBase', () => {
         });
     });
     describe('callbacks', () => {
-        describe('onSelectionChange', () => {
+        describe('onSelectionAdd', () => {
             it('should be called on clicking on a suggestion', () => {
                 setFocusOnInput();
 
-                expect(mockOnSelectionChange).not.toHaveBeenCalled();
+                expect(mockOnSelectionAdd).not.toHaveBeenCalled();
 
                 wrapper.find('li').first().children().simulate('click');
 
-                expect(mockOnSelectionChange).toHaveBeenCalled();
+                expect(mockOnSelectionAdd).toHaveBeenCalled();
             });
         });
         it('should call onClearAllSelected on Clear button click', () => {

--- a/src/components/Select/SelectBase/__tests__/__snapshots__/SelectBase.spec.js.snap
+++ b/src/components/Select/SelectBase/__tests__/__snapshots__/SelectBase.spec.js.snap
@@ -70,7 +70,7 @@ exports[`SelectBase rendering should initially render empty component correctly 
   onBlur={[MockFunction]}
   onClearAllSelected={[MockFunction]}
   onInputValueChange={[MockFunction]}
-  onSelectionChange={[MockFunction]}
+  onSelectionAdd={[MockFunction]}
   selectOnTab={false}
   showClearButton={false}
   suggestionToString={[Function]}

--- a/src/components/Select/SelectBase/interfaces.ts
+++ b/src/components/Select/SelectBase/interfaces.ts
@@ -5,7 +5,7 @@ export interface CommonProps<S> extends React.HTMLAttributes<HTMLDivElement> {
     suggestions: S[];
     /** suggestionToString(suggestion) should return a string to be displayed in the UI. e.g.: suggestion => suggestion.name */
     suggestionToString: (suggestions?: S | null) => string;
-    /** render function for suggestion list item */
+    /** render function for suggestion list item. If undefined, suggestionToString will be used. */
     suggestionItemRenderer?: (suggestions?: S | null) => ReactNode;
     /** if suggestions are still loading, i.e. display placeholders */
     isLoading?: boolean;
@@ -19,7 +19,7 @@ export interface CommonProps<S> extends React.HTMLAttributes<HTMLDivElement> {
     onFocus?: () => void;
     /** onBlur() is called when the component is blurred */
     onBlur?: () => void;
-    /** onSelectionAdd() called when a suggestion is selected or removed */
+    /** onSelectionAdd() called when a suggestion is selected */
     onSelectionAdd: (item: S) => void;
     /** onInputValueChange(inputValue) called when the input values is changed. Can be used to implement the component as controlled component */
     onInputValueChange: (value: string) => void;

--- a/src/components/Select/SelectBase/interfaces.ts
+++ b/src/components/Select/SelectBase/interfaces.ts
@@ -19,8 +19,8 @@ export interface CommonProps<S> extends React.HTMLAttributes<HTMLDivElement> {
     onFocus?: () => void;
     /** onBlur() is called when the component is blurred */
     onBlur?: () => void;
-    /** onSelectionChange() called when a suggestion is selected or removed */
-    onSelectionChange: (item: S) => void;
+    /** onSelectionAdd() called when a suggestion is selected or removed */
+    onSelectionAdd: (item: S) => void;
     /** onInputValueChange(inputValue) called when the input values is changed. Can be used to implement the component as controlled component */
     onInputValueChange: (value: string) => void;
     /** clean up input value after selected item */

--- a/src/components/Select/SuggestionsList/SuggestionsList.tsx
+++ b/src/components/Select/SuggestionsList/SuggestionsList.tsx
@@ -20,7 +20,7 @@ export interface Props<S> {
     suggestionToString: (suggestion: S) => string;
     /** suggestionToKey(suggestion) makes a key to be used for a suggestion item */
     suggestionToKey?: (suggestion: S) => string;
-    /** render function for suggestion list item */
+    /** render function for suggestion list item. If undefined `suggestionToString` will be used */
     suggestionItemRenderer?: (suggestion: S) => ReactNode;
     /** to be shown when no suggestions are available */
     noSuggestionsPlaceholder?: string;

--- a/stories/Select.tsx
+++ b/stories/Select.tsx
@@ -40,8 +40,8 @@ storiesOf('Organisms|Select', module)
             store.set({ inputValue: value });
         };
 
-        const onSelectionChange = (item: TSuggestion) => {
-            console.log(`onSelectionChange was called with {name: ${item?.name}}`);
+        const onSelectionAdd = (item: TSuggestion) => {
+            console.log(`onSelectionAdd was called with {name: ${item?.name}}`);
             store.set({ selectedSuggestions: [...store.get('selectedSuggestions'), item] });
         };
 
@@ -74,7 +74,7 @@ storiesOf('Organisms|Select', module)
                     suggestionToString={SUGGESTION_TO_STRING}
                     onFocus={onFocus}
                     onBlur={onBlur}
-                    onSelectionChange={onSelectionChange}
+                    onSelectionAdd={onSelectionAdd}
                     onInputValueChange={onInputValueChange}
                 />
             </>
@@ -107,8 +107,8 @@ storiesOf('Organisms|Select', module)
             store.set({ inputValue: value });
         };
 
-        const onSelectionChange = (item: TSuggestion) => {
-            console.log(`onSelectionChange was called with {name: ${item.name}}`);
+        const onSelectionAdd = (item: TSuggestion) => {
+            console.log(`onSelectionAdd was called with {name: ${item.name}}`);
             let selectedItem = { ...item };
             if (item === searchFor) {
                 selectedItem = { name: (item as typeof searchFor).value };
@@ -174,7 +174,7 @@ storiesOf('Organisms|Select', module)
                         boolean('First item is always visible', false) &&
                         !!store.get('inputValue').length
                     }
-                    onSelectionChange={onSelectionChange}
+                    onSelectionAdd={onSelectionAdd}
                     onSelectionRemove={onSelectionRemove}
                     isProminent={boolean('Use prominent styling', true)}
                     isLoading={boolean('isLoading', false)}


### PR DESCRIPTION
Story: [ONEUI-199](https://jira.textkernel.nl/browse/ONEUI-199)

* add `noSuggestionsPlaceholder` support to AutosuggestMulti
* update props descriptions

BREAKING CHANGE:
* rename `onSuggestionChange` to `onSuggestionAdd` to align with already existing `onSuggestionRemove` prop. Effects AutosuggestMulti and ComboboxMulti