### PR TITLE
fix(PopupBase): made PopupBase#wasPopupClicked() work in FF

### DIFF
--- a/src/components/PopupBase/PopupBase.js
+++ b/src/components/PopupBase/PopupBase.js
@@ -55,8 +55,8 @@ export class PopupBase extends React.Component {
     }
 
     wasPopupClicked(event) {
-        if (event.path && this.anchorRef.current) {
-            return Array.from(event.path).some((node) => {
+        if (event.composedPath && this.anchorRef.current) {
+            return Array.from(event.composedPath()).some((node) => {
                 // Must be Element node
                 if (node.nodeType === 1) {
                     return this.popupRef.current.contains(node);

--- a/src/components/PopupBase/__tests__/PopupBase.spec.js
+++ b/src/components/PopupBase/__tests__/PopupBase.spec.js
@@ -122,7 +122,7 @@ describe('<PopupBase> that adds basic anchor/popup functionality to rendered com
 
             // clicking directly in the element won't trigger global listener, hence we use our magic mock
             mockDocumentEventListener.click({
-                path: [wrapper.find('Popover').find('p').at(0).getDOMNode()],
+                composedPath: () => [wrapper.find('Popover').find('p').at(0).getDOMNode()],
             });
             wrapper.update();
 


### PR DESCRIPTION
Make PopupBase work correctly in FireFox, Safari, and IE11

A Chrome specific event's property "path" was used in PopupBase component.
It was replaced with Event#composedPath(), that is supported by FF and Safari.

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
