### PR TITLE
feat: add statuses to Teaser

### DIFF
--- a/src/components/Teaser/Teaser.scss
+++ b/src/components/Teaser/Teaser.scss
@@ -2,10 +2,22 @@
     min-width: 0;
     margin: 0;
     display: flex;
+    flex: 1;
     flex-direction: column;
+    height: 63px;
 
-    &__titleLine {
+    &__line {
         display: flex;
+        flex: 1;
+        align-items: center;
+        padding-bottom: var(--spacing-2x);
+    }
+
+    &__lastLine {
+        display: flex;
+        flex: 1;
+        align-items: center;
+        justify-content: flex-end;
     }
 
     &__title {
@@ -28,8 +40,14 @@
         text-overflow: ellipsis;
     }
 
-    &__titleLine:not(:last-child),
-    &__subTitle:not(:last-child) {
-        padding-bottom: var(--spacing-2x);
+    &__details {
+        flex: 1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    &__statuses {
+        padding-left: var(--spacing-2x);
     }
 }

--- a/src/components/Teaser/Teaser.scss
+++ b/src/components/Teaser/Teaser.scss
@@ -11,13 +11,11 @@
         flex: 1;
         align-items: center;
         padding-bottom: var(--spacing-2x);
-    }
 
-    &__lastLine {
-        display: flex;
-        flex: 1;
-        align-items: center;
-        justify-content: flex-end;
+        &:last-child {
+            padding-bottom: 0;
+            justify-content: flex-end;
+        }
     }
 
     &__title {
@@ -48,6 +46,6 @@
     }
 
     &__statuses {
-        padding-left: var(--spacing-2x);
+        padding-left: var(--spacing-5x);
     }
 }

--- a/src/components/Teaser/Teaser.tsx
+++ b/src/components/Teaser/Teaser.tsx
@@ -27,6 +27,16 @@ const { block, elem } = bem('Teaser', styles);
 export const Teaser: React.FC<Props> = (props) => {
     const { title, subTitle, location, details, statuses, ...rest } = props;
 
+    const subTitleElement = (
+        <Text inline context="accent" {...elem('subTitle', props)}>
+            {subTitle}
+        </Text>
+    );
+    const detailsElement = (
+        <Text inline context="muted" {...elem('details', props)}>
+            {details}
+        </Text>
+    );
     return (
         <div {...rest} {...block(props)}>
             <div {...elem('line', props)}>
@@ -40,23 +50,11 @@ export const Teaser: React.FC<Props> = (props) => {
                 )}
             </div>
             <div {...elem('line', props)}>
-                {subTitle && (
-                    <Text inline context="accent" {...elem('subTitle', props)}>
-                        {subTitle}
-                    </Text>
-                )}
-                {!subTitle && details && (
-                    <Text inline context="muted" {...elem('details', props)}>
-                        {details}
-                    </Text>
-                )}
+                {subTitle && subTitleElement}
+                {!subTitle && details && detailsElement}
             </div>
-            <div {...elem('lastLine', props)}>
-                {subTitle && details && (
-                    <Text inline context="muted" {...elem('details', props)}>
-                        {details}
-                    </Text>
-                )}
+            <div {...elem('line', props)}>
+                {subTitle && details && detailsElement}
                 {statuses && statuses.length > 0 && (
                     <div {...elem('statuses', props)}>
                         {statuses.map(({ label, tooltip }, index) => (

--- a/src/components/Teaser/Teaser.tsx
+++ b/src/components/Teaser/Teaser.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { bem } from '../../utils';
 import { Text } from '../Text';
+import { Tooltip } from '../Tooltip';
 import styles from './Teaser.scss';
+
+type Status = {
+    label: string;
+    tooltip: string;
+};
 
 interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
     /** The title of entity */
@@ -12,16 +18,18 @@ interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
     location?: SingleReactNode;
     /** Details related to the entity */
     details?: SingleReactNode;
+    /** Statuses of entity containing status label and tooltip message */
+    statuses?: Status[];
 }
 
 const { block, elem } = bem('Teaser', styles);
 
 export const Teaser: React.FC<Props> = (props) => {
-    const { title, subTitle, location, details, ...rest } = props;
+    const { title, subTitle, location, details, statuses, ...rest } = props;
 
     return (
         <div {...rest} {...block(props)}>
-            <div {...elem('titleLine', props)}>
+            <div {...elem('line', props)}>
                 <Text inline context="brand" {...elem('title', props)}>
                     {title}
                 </Text>
@@ -31,16 +39,43 @@ export const Teaser: React.FC<Props> = (props) => {
                     </Text>
                 )}
             </div>
-            {subTitle && (
-                <Text inline context="accent" {...elem('subTitle', props)}>
-                    {subTitle}
-                </Text>
-            )}
-            {details && (
-                <Text inline context="muted">
-                    {details}
-                </Text>
-            )}
+            <div {...elem('line', props)}>
+                {subTitle && (
+                    <Text inline context="accent" {...elem('subTitle', props)}>
+                        {subTitle}
+                    </Text>
+                )}
+                {!subTitle && details && (
+                    <Text inline context="muted" {...elem('details', props)}>
+                        {details}
+                    </Text>
+                )}
+            </div>
+            <div {...elem('lastLine', props)}>
+                {subTitle && details && (
+                    <Text inline context="muted" {...elem('details', props)}>
+                        {details}
+                    </Text>
+                )}
+                {statuses && statuses.length > 0 && (
+                    <div {...elem('statuses', props)}>
+                        {statuses.map(({ label, tooltip }, index) => (
+                            <span key={label}>
+                                <Tooltip content={tooltip}>
+                                    <Text inline context="muted" size="small">
+                                        {label}
+                                    </Text>
+                                </Tooltip>
+                                {index < statuses.length - 1 && (
+                                    <Text inline context="muted" size="small">
+                                        {' & '}
+                                    </Text>
+                                )}
+                            </span>
+                        ))}
+                    </div>
+                )}
+            </div>
         </div>
     );
 };

--- a/src/components/Teaser/__tests__/Teaser.spec.js
+++ b/src/components/Teaser/__tests__/Teaser.spec.js
@@ -15,6 +15,16 @@ describe('Teaser', () => {
                 location="location"
                 subTitle="Organization"
                 details="details about this job"
+                statuses={[
+                    {
+                        label: 'Viewed',
+                        tooltip: 'Viewed two days ago',
+                    },
+                    {
+                        label: 'Imported',
+                        tooltip: 'Imported five days ago',
+                    },
+                ]}
             />
         );
 

--- a/src/components/Teaser/__tests__/__snapshots__/Teaser.spec.js.snap
+++ b/src/components/Teaser/__tests__/__snapshots__/Teaser.spec.js.snap
@@ -30,7 +30,7 @@ exports[`Teaser should render correctly with just a title 1`] = `
       className="Teaser__line"
     />
     <div
-      className="Teaser__lastLine"
+      className="Teaser__line"
     />
   </div>
 </Teaser>
@@ -103,7 +103,7 @@ exports[`Teaser should render with all props defined 1`] = `
       </Text>
     </div>
     <div
-      className="Teaser__lastLine"
+      className="Teaser__line"
     >
       <Text
         className="Teaser__details"

--- a/src/components/Teaser/__tests__/__snapshots__/Teaser.spec.js.snap
+++ b/src/components/Teaser/__tests__/__snapshots__/Teaser.spec.js.snap
@@ -11,7 +11,7 @@ exports[`Teaser should render correctly with just a title 1`] = `
     className="Teaser"
   >
     <div
-      className="Teaser__titleLine"
+      className="Teaser__line"
     >
       <Text
         className="Teaser__title"
@@ -26,6 +26,12 @@ exports[`Teaser should render correctly with just a title 1`] = `
         </span>
       </Text>
     </div>
+    <div
+      className="Teaser__line"
+    />
+    <div
+      className="Teaser__lastLine"
+    />
   </div>
 </Teaser>
 `;
@@ -34,6 +40,18 @@ exports[`Teaser should render with all props defined 1`] = `
 <Teaser
   details="details about this job"
   location="location"
+  statuses={
+    Array [
+      Object {
+        "label": "Viewed",
+        "tooltip": "Viewed two days ago",
+      },
+      Object {
+        "label": "Imported",
+        "tooltip": "Imported five days ago",
+      },
+    ]
+  }
   subTitle="Organization"
   title="A job title"
 >
@@ -41,7 +59,7 @@ exports[`Teaser should render with all props defined 1`] = `
     className="Teaser"
   >
     <div
-      className="Teaser__titleLine"
+      className="Teaser__line"
     >
       <Text
         className="Teaser__title"
@@ -68,29 +86,131 @@ exports[`Teaser should render with all props defined 1`] = `
         </span>
       </Text>
     </div>
-    <Text
-      className="Teaser__subTitle"
-      context="accent"
-      inline={true}
-      size="normal"
+    <div
+      className="Teaser__line"
     >
-      <span
-        className="Text--context_accent Teaser__subTitle"
+      <Text
+        className="Teaser__subTitle"
+        context="accent"
+        inline={true}
+        size="normal"
       >
-        Organization
-      </span>
-    </Text>
-    <Text
-      context="muted"
-      inline={true}
-      size="normal"
+        <span
+          className="Text--context_accent Teaser__subTitle"
+        >
+          Organization
+        </span>
+      </Text>
+    </div>
+    <div
+      className="Teaser__lastLine"
     >
-      <span
-        className="Text--context_muted"
+      <Text
+        className="Teaser__details"
+        context="muted"
+        inline={true}
+        size="normal"
       >
-        details about this job
-      </span>
-    </Text>
+        <span
+          className="Text--context_muted Teaser__details"
+        >
+          details about this job
+        </span>
+      </Text>
+      <div
+        className="Teaser__statuses"
+      >
+        <span
+          key="Viewed"
+        >
+          <Tooltip
+            animation="shift-toward"
+            content="Viewed two days ago"
+          >
+            <ForwardRef(TippyWrapper)
+              animation="shift-toward"
+              content="Viewed two days ago"
+            >
+              <Tippy
+                animation="shift-toward"
+                content="Viewed two days ago"
+              >
+                <Text
+                  context="muted"
+                  inline={true}
+                  size="small"
+                >
+                  <span
+                    className="Text--context_muted Text--size_small"
+                  >
+                    Viewed
+                  </span>
+                </Text>
+                <Portal
+                  containerInfo={
+                    <div>
+                      Viewed two days ago
+                    </div>
+                  }
+                >
+                  Viewed two days ago
+                </Portal>
+              </Tippy>
+            </ForwardRef(TippyWrapper)>
+          </Tooltip>
+          <Text
+            context="muted"
+            inline={true}
+            size="small"
+          >
+            <span
+              className="Text--context_muted Text--size_small"
+            >
+               & 
+            </span>
+          </Text>
+        </span>
+        <span
+          key="Imported"
+        >
+          <Tooltip
+            animation="shift-toward"
+            content="Imported five days ago"
+          >
+            <ForwardRef(TippyWrapper)
+              animation="shift-toward"
+              content="Imported five days ago"
+            >
+              <Tippy
+                animation="shift-toward"
+                content="Imported five days ago"
+              >
+                <Text
+                  context="muted"
+                  inline={true}
+                  size="small"
+                >
+                  <span
+                    className="Text--context_muted Text--size_small"
+                  >
+                    Imported
+                  </span>
+                </Text>
+                <Portal
+                  containerInfo={
+                    <div>
+                      Imported five days ago
+                    </div>
+                  }
+                >
+                  Imported five days ago
+                </Portal>
+              </Tippy>
+            </ForwardRef(TippyWrapper)>
+          </Tooltip>
+        </span>
+      </div>
+    </div>
   </div>
 </Teaser>
 `;

--- a/stories/Teaser.tsx
+++ b/stories/Teaser.tsx
@@ -5,7 +5,7 @@ import { Teaser } from '@textkernel/oneui';
 
 storiesOf('Molecules|Teaser', module)
     .addDecorator(withKnobs)
-    .add('all fields', () => {
+    .add('With all fields', () => {
         const title = text('Title', 'My first job');
         return (
             <Teaser
@@ -26,7 +26,7 @@ storiesOf('Molecules|Teaser', module)
             />
         );
     })
-    .add('with one status', () => {
+    .add('With one status', () => {
         const title = text('Title', 'My first job');
         return (
             <Teaser
@@ -43,7 +43,7 @@ storiesOf('Molecules|Teaser', module)
             />
         );
     })
-    .add('without statuses', () => {
+    .add('Without statuses', () => {
         const title = text('Title', 'My first job');
         return (
             <Teaser

--- a/stories/Teaser.tsx
+++ b/stories/Teaser.tsx
@@ -1,18 +1,56 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { object, text, withKnobs } from '@storybook/addon-knobs';
 import { Teaser } from '@textkernel/oneui';
 
 storiesOf('Molecules|Teaser', module)
     .addDecorator(withKnobs)
-    .add('Teaser', () => {
+    .add('all fields', () => {
         const title = text('Title', 'My first job');
         return (
             <Teaser
                 title={<span title={title}>{title}</span>}
                 subTitle={text('SubTitle', 'Awsome inc.')}
                 location={text('Location', 'Melbourne')}
-                details={text('Details', 'It was posted here, yesterday')}
+                details={text('Details', 'It was posted here')}
+                statuses={[
+                    object('Viewed status', {
+                        label: 'Viewed',
+                        tooltip: 'Viewed one day ago',
+                    }),
+                    object('Imported status', {
+                        label: 'Imported',
+                        tooltip: 'Imported two days ago',
+                    }),
+                ]}
+            />
+        );
+    })
+    .add('with one status', () => {
+        const title = text('Title', 'My first job');
+        return (
+            <Teaser
+                title={<span title={title}>{title}</span>}
+                subTitle={text('SubTitle', 'Awsome inc.')}
+                location={text('Location', 'Melbourne')}
+                details={text('Details', 'It was posted here')}
+                statuses={[
+                    object('Viewed status', {
+                        label: 'Viewed',
+                        tooltip: 'Viewed one day ago',
+                    }),
+                ]}
+            />
+        );
+    })
+    .add('without statuses', () => {
+        const title = text('Title', 'My first job');
+        return (
+            <Teaser
+                title={<span title={title}>{title}</span>}
+                subTitle={text('SubTitle', 'Awsome inc.')}
+                location={text('Location', 'Melbourne')}
+                details={text('Details', 'It was posted here')}
             />
         );
     });


### PR DESCRIPTION
- add statuses array
- add fixed height
- implement 3 rows architecture where:
 1.  `title` + `location`
 2.  `subTitle` (or `details` if no `subTitle`)
3.  `details` (if there is `subTitle`) + `statuses` (always on the last row in the right split by ` & `)

![image](https://user-images.githubusercontent.com/17009609/97146603-698fc700-1768-11eb-8911-dceccf2a58dd.png)
- updated storybook story of Teaser component. I created 3 stories:
1. all fields
2. with one status
3. without statuses
I had to do this, because in storybook we can't change count of array elements or remove array at all. Also I don't want to create some `withStatuses` boolean knob, because it doesn't represent any real component prop.
