### PR TITLE
fix(Callout): stretch content on full width

### DIFF
--- a/src/components/Callout/Callout.scss
+++ b/src/components/Callout/Callout.scss
@@ -7,6 +7,10 @@ $icon-size: 16px;
     padding: var(--spacing-5x);
     align-items: flex-start;
 
+    &__content {
+        flex-grow: 1;
+    }
+
     &__closeButton {
         display: block;
         flex-shrink: 0;

--- a/src/components/Callout/__tests__/__snapshots__/Callout.spec.js.snap
+++ b/src/components/Callout/__tests__/__snapshots__/Callout.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Callout should render correctly 1`] = `
   className="Callout Callout--context_info"
 >
   <div
-    className="Callout__content--context_info"
+    className="Callout__content Callout__content--context_info"
   >
     some text
   </div>


### PR DESCRIPTION
The Callout's content width fills a whole free width of Callout.

# Checklist
- [ ] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [ ] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [ ] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [ ] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [ ] Component PropTypes are sufficiently described / documented.
- [ ] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
