### PR TITLE
fix(ButtonGroup): add classnames to style first and last button

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -6,26 +6,27 @@
     &__button {
         border-radius: 0;
 
-        &:first-child {
+        &--first {
             border-top-left-radius: var(--border-radius);
             border-bottom-left-radius: var(--border-radius);
         }
-        &:last-child {
+
+        &--last {
             border-top-right-radius: var(--border-radius);
             border-bottom-right-radius: var(--border-radius);
         }
 
-        + .ButtonGroup__button {
+        ~ .ButtonGroup__button {
             margin-left: -1px;
         }
 
         &--context {
             @each $context in ($contexts) {
                 &_#{$context} {
-                    &:not(:first-child):not(:focus) {
+                    &:not(.ButtonGroup__button--first):not(:focus) {
                         border-left-color: var(--color-#{$context}-25);
                     }
-                    &:not(:last-child):not(:focus) {
+                    &:not(.ButtonGroup__button--last):not(:focus) {
                         border-right-color: var(--color-#{$context}-25);
                     }
                 }

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -20,9 +20,11 @@ const { block, elem } = bem('ButtonGroup', styles);
 export const ButtonGroup: React.FC<Props> = (props) => {
     const { children, context, size, isBlock, ...rest } = props;
 
+    const totalNumberOfButtons = React.Children.count(children);
+
     return (
         <div {...rest} {...block(props)} role="group">
-            {React.Children.map(children, (button) => {
+            {React.Children.map(children, (button, i) => {
                 if (!React.isValidElement(button)) {
                     return button;
                 }
@@ -31,7 +33,11 @@ export const ButtonGroup: React.FC<Props> = (props) => {
                     ...button.props,
                     context,
                     size,
-                    ...elem('button', props),
+                    ...elem('button', {
+                        ...props,
+                        first: i === 0,
+                        last: i + 1 === totalNumberOfButtons,
+                    }),
                 });
             })}
         </div>

--- a/src/components/ButtonGroup/__tests__/ButtonGroup.spec.js
+++ b/src/components/ButtonGroup/__tests__/ButtonGroup.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 import { ButtonGroup } from '../ButtonGroup';
 import { Button } from '../../Buttons';
-import { MultiActionButton } from '../../MultiActionButton';
+import { Dropdown } from '../../Dropdown';
 import { ListItem } from '../../List/ListItem';
 
 describe('<ButtonGroup> that renders a button', () => {
@@ -31,12 +31,9 @@ describe('<ButtonGroup> that renders a button', () => {
             <ButtonGroup size="large" isBlock>
                 <Button>A button</Button>
                 <Button href="#">An anchor</Button>
-                <MultiActionButton
-                    button={<Button>A dropdown button</Button>}
-                    placement="bottom-end"
-                >
+                <Dropdown button={<Button>A dropdown button</Button>} placement="bottom-end">
                     <ListItem key="some-key">A list item</ListItem>
-                </MultiActionButton>
+                </Dropdown>
             </ButtonGroup>
         );
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/src/components/ButtonGroup/__tests__/ButtonGroup.spec.js
+++ b/src/components/ButtonGroup/__tests__/ButtonGroup.spec.js
@@ -2,6 +2,8 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 import { ButtonGroup } from '../ButtonGroup';
 import { Button } from '../../Buttons';
+import { MultiActionButton } from '../../MultiActionButton';
+import { ListItem } from '../../List/ListItem';
 
 describe('<ButtonGroup> that renders a button', () => {
     it('should render default button correctly', () => {
@@ -19,6 +21,22 @@ describe('<ButtonGroup> that renders a button', () => {
             <ButtonGroup size="large" isBlock>
                 <Button>A button</Button>
                 <Button>Another button</Button>
+            </ButtonGroup>
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should support mixed element types', () => {
+        const wrapper = mount(
+            <ButtonGroup size="large" isBlock>
+                <Button>A button</Button>
+                <Button href="#">An anchor</Button>
+                <MultiActionButton
+                    button={<Button>A dropdown button</Button>}
+                    placement="bottom-end"
+                >
+                    <ListItem key="some-key">A list item</ListItem>
+                </MultiActionButton>
             </ButtonGroup>
         );
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -11,7 +11,7 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
     role="group"
   >
     <Button
-      className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral"
+      className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--first"
       context="neutral"
       disabled={false}
       isBlock={false}
@@ -21,7 +21,7 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
       type="button"
     >
       <button
-        className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral"
+        className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--first"
         disabled={false}
         type="button"
       >
@@ -29,7 +29,7 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
       </button>
     </Button>
     <Button
-      className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral"
+      className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--last"
       context="neutral"
       disabled={false}
       isBlock={false}
@@ -39,7 +39,7 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
       type="button"
     >
       <button
-        className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral"
+        className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--last"
         disabled={false}
         type="button"
       >
@@ -61,7 +61,7 @@ exports[`<ButtonGroup> that renders a button should render default button correc
     role="group"
   >
     <Button
-      className="ButtonGroup__button ButtonGroup__button--context_neutral"
+      className="ButtonGroup__button ButtonGroup__button--context_neutral ButtonGroup__button--first"
       context="neutral"
       disabled={false}
       isBlock={false}
@@ -71,7 +71,7 @@ exports[`<ButtonGroup> that renders a button should render default button correc
       type="button"
     >
       <button
-        className="Button Button--context_neutral ButtonGroup__button ButtonGroup__button--context_neutral"
+        className="Button Button--context_neutral ButtonGroup__button ButtonGroup__button--context_neutral ButtonGroup__button--first"
         disabled={false}
         type="button"
       >
@@ -79,7 +79,7 @@ exports[`<ButtonGroup> that renders a button should render default button correc
       </button>
     </Button>
     <Button
-      className="ButtonGroup__button ButtonGroup__button--context_neutral"
+      className="ButtonGroup__button ButtonGroup__button--context_neutral ButtonGroup__button--last"
       context="neutral"
       disabled={false}
       isBlock={false}
@@ -89,13 +89,135 @@ exports[`<ButtonGroup> that renders a button should render default button correc
       type="button"
     >
       <button
-        className="Button Button--context_neutral ButtonGroup__button ButtonGroup__button--context_neutral"
+        className="Button Button--context_neutral ButtonGroup__button ButtonGroup__button--context_neutral ButtonGroup__button--last"
         disabled={false}
         type="button"
       >
         Another button
       </button>
     </Button>
+  </div>
+</ButtonGroup>
+`;
+
+exports[`<ButtonGroup> that renders a button should support mixed element types 1`] = `
+<ButtonGroup
+  context="neutral"
+  isBlock={true}
+  size="large"
+>
+  <div
+    className="ButtonGroup ButtonGroup--isBlock"
+    role="group"
+  >
+    <Button
+      className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--first"
+      context="neutral"
+      disabled={false}
+      isBlock={false}
+      isInline={false}
+      key=".0"
+      size="large"
+      type="button"
+    >
+      <button
+        className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--first"
+        disabled={false}
+        type="button"
+      >
+        A button
+      </button>
+    </Button>
+    <Button
+      className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral"
+      context="neutral"
+      disabled={false}
+      href="#"
+      isBlock={false}
+      isInline={false}
+      key=".1"
+      size="large"
+      type="button"
+    >
+      <a
+        className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral"
+        href="#"
+      >
+        An anchor
+      </a>
+    </Button>
+    <MultiActionButton
+      button={
+        <ForwardRef
+          context="neutral"
+          disabled={false}
+          isBlock={false}
+          isInline={false}
+          size="normal"
+          type="button"
+        >
+          A dropdown button
+        </ForwardRef>
+      }
+      className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--last"
+      context="neutral"
+      key=".2"
+      placement="bottom-end"
+      size="large"
+    >
+      <Button
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        aria-labelledby="downshift-0-label downshift-0-toggle-button"
+        className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--last"
+        context="neutral"
+        disabled={false}
+        id="downshift-0-toggle-button"
+        isBlock={false}
+        isInline={false}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        size="large"
+        type="button"
+      >
+        <button
+          aria-expanded={false}
+          aria-haspopup="listbox"
+          aria-labelledby="downshift-0-label downshift-0-toggle-button"
+          className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--last"
+          disabled={false}
+          id="downshift-0-toggle-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          type="button"
+        >
+          A dropdown button
+        </button>
+      </Button>
+      <List
+        aria-labelledby="downshift-0-label"
+        doSelectOnNavigate={false}
+        id="downshift-0-menu"
+        isControlledNavigation={true}
+        isDivided={false}
+        onBlur={[Function]}
+        onKeyDown={[Function]}
+        onMouseLeave={[Function]}
+        role="listbox"
+        tabIndex={-1}
+      >
+        <ul
+          aria-labelledby="downshift-0-label"
+          className="List"
+          id="downshift-0-menu"
+          onBlur={[Function]}
+          onKeyDown={[Function]}
+          onMouseLeave={[Function]}
+          role="listbox"
+          tabIndex={-1}
+        />
+      </List>
+    </MultiActionButton>
   </div>
 </ButtonGroup>
 `;

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -146,7 +146,7 @@ exports[`<ButtonGroup> that renders a button should support mixed element types 
         An anchor
       </a>
     </Button>
-    <MultiActionButton
+    <Dropdown
       button={
         <ForwardRef
           context="neutral"
@@ -217,7 +217,7 @@ exports[`<ButtonGroup> that renders a button should support mixed element types 
           tabIndex={-1}
         />
       </List>
-    </MultiActionButton>
+    </Dropdown>
   </div>
 </ButtonGroup>
 `;


### PR DESCRIPTION
Adds `.ButtonGroup__button--first` and `.ButtonGroup__button--last` classnames for selecting the first and last buttons in a `ButtonGroup`, instead of relying on CSS pseudo-classes.

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
