### PR TITLE
fix(TwoPaneView): right pane doesn't jump too much on scroll

### DIFF
--- a/src/components/TwoPaneView/RightPane/RightPane.scss
+++ b/src/components/TwoPaneView/RightPane/RightPane.scss
@@ -1,7 +1,6 @@
 .RightPane {
-    position: absolute;
+    top: 0;
     left: calc(var(--two-pane-left-width) + var(--site-container-padding));
-    display: inline-block;
     box-sizing: border-box;
     overflow: hidden;
 }

--- a/src/components/TwoPaneView/TwoPaneView.scss
+++ b/src/components/TwoPaneView/TwoPaneView.scss
@@ -2,26 +2,4 @@
     margin-top: 30px;
     margin-bottom: 30px;
     position: relative;
-
-    &__leftPane,
-    &__rightPane {
-        display: inline-block;
-        box-sizing: border-box;
-        background-color: var(--color-background);
-        border: solid 1px var(--color-neutral-40);
-    }
-
-    &__leftPane {
-        width: 550px;
-        border-radius: var(--border-radius) 0 0 var(--border-radius);
-    }
-
-    &__rightPane {
-        position: absolute;
-        left: 570px;
-        border-radius: 0 var(--border-radius) var(--border-radius) 0;
-        border-left: 0;
-        width: calc(var(--site-container-max-size) - 2 * var(--site-container-padding) - 550px);
-        padding: var(--spacing-normal);
-    }
 }

--- a/src/components/TwoPaneView/TwoPaneView.tsx
+++ b/src/components/TwoPaneView/TwoPaneView.tsx
@@ -15,7 +15,8 @@ const { block } = bem('TwoPaneView', styles);
 export const TwoPaneView: React.FC<Props> = (props) => {
     const { children, ...rest } = props;
 
-    const [rightTop, setRightTop] = React.useState(0);
+    const [rightPosition, setRightPosition] = React.useState('absolute');
+    const [rightLeft, setRightLeft] = React.useState<number | undefined>(undefined);
     const [rightHeight, setRightHeight] = React.useState(200);
     const [rightWidth, setRightWidth] = React.useState(600);
     const [doDisplayRightPane, setDoDisplayRightPane] = React.useState(true);
@@ -33,14 +34,16 @@ export const TwoPaneView: React.FC<Props> = (props) => {
         }
 
         const leftDimensions = leftEl.getBoundingClientRect();
-        const top = leftDimensions.top > 0 ? 0 : -leftDimensions.top;
+        const position = leftDimensions.top > 0 ? 'absolute' : 'fixed';
+        const left = leftDimensions.top > 0 ? undefined : leftDimensions.right;
 
         const height =
             Math.min(window.innerHeight, leftDimensions.bottom) - Math.max(leftDimensions.top, 0);
 
         const doDisplay = leftDimensions.bottom > 0;
 
-        setRightTop(top);
+        setRightPosition(position);
+        setRightLeft(left);
         setRightHeight(height);
         setDoDisplayRightPane(doDisplay);
     };
@@ -86,7 +89,8 @@ export const TwoPaneView: React.FC<Props> = (props) => {
                         ? React.cloneElement(child, {
                               style: {
                                   ...childStyle,
-                                  top: rightTop,
+                                  position: rightPosition,
+                                  left: rightLeft,
                                   height: rightHeight,
                                   width: rightWidth,
                                   display: doDisplayRightPane ? 'inline-block' : 'none',

--- a/src/components/TwoPaneView/__tests__/__snapshots__/TwoPaneView.spec.js.snap
+++ b/src/components/TwoPaneView/__tests__/__snapshots__/TwoPaneView.spec.js.snap
@@ -24,7 +24,8 @@ exports[`<TwoPaneView> that renders a two pane view should render correctly 1`] 
           Object {
             "display": "none",
             "height": 0,
-            "top": -0,
+            "left": 0,
+            "position": "fixed",
             "width": 0,
           }
         }
@@ -35,7 +36,8 @@ exports[`<TwoPaneView> that renders a two pane view should render correctly 1`] 
             Object {
               "display": "none",
               "height": 0,
-              "top": -0,
+              "left": 0,
+              "position": "fixed",
               "width": 0,
             }
           }

--- a/stories/TwoPaneView.tsx
+++ b/stories/TwoPaneView.tsx
@@ -10,7 +10,7 @@ storiesOf('Molecules|TwoPaneView', module)
             <LeftPane
                 style={{
                     minHeight: text('Height of left pane', '600px'),
-                    backgroundColor: 'var(--color-background)',
+                    backgroundColor: 'var(--color-info-25)',
                     border: 'solid 1px var(--color-neutral-40)',
                     borderRadius: 'var(--border-radius) 0 0 var(--border-radius)',
                 }}
@@ -19,7 +19,7 @@ storiesOf('Molecules|TwoPaneView', module)
             </LeftPane>
             <RightPane
                 style={{
-                    backgroundColor: 'var(--color-background)',
+                    backgroundColor: 'var(--color-good-25)',
                     border: 'solid 1px var(--color-neutral-40)',
                     borderRadius: '0 var(--border-radius) var(--border-radius) 0',
                     borderLeft: 0,


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. Use imperative, present tense in your commit description ("change", not "changed" or "changes") without uppercases or period (.) at the end.

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
