### PR TITLE
fix(Dropdown): children type

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -18,7 +18,10 @@ interface Props<V> extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'
      *  and empty/false `disabled` attribute.
      *  Use {@link ListItem} component.
      */
-    children: React.ReactElement<ListItemProps> | React.ReactElement<ListItemProps>[];
+    children:
+        | React.ReactElement<ListItemProps>
+        | React.ReactElement<ListItemProps>[]
+        | (React.ReactElement<ListItemProps> | React.ReactElement<ListItemProps>[])[];
     /** {@link Button} element, controlled by current component */
     button: React.FunctionComponentElement<ButtonProps>;
     /**

--- a/src/components/Dropdown/__tests__/Dropdown.spec.js
+++ b/src/components/Dropdown/__tests__/Dropdown.spec.js
@@ -117,4 +117,27 @@ describe('Dropdown', () => {
 
         wrapper.unmount();
     });
+
+    it('should render correctly with mixed children: array and single ListItem', () => {
+        wrapper = mount(
+            <Dropdown
+                button={<Button context="brand">Click me!</Button>}
+                onChange={mockOnChange}
+                placement="top-start"
+            >
+                <ListItem key="disabled-key" disabled>
+                    Disabled
+                </ListItem>
+                {['one', 'two'].map((value) => (
+                    <ListItem key={value} value={value}>
+                        {value}
+                    </ListItem>
+                ))}
+            </Dropdown>
+        );
+        wrapper.find('button').simulate('click');
+        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(wrapper.find('ListItem')).toHaveLength(3);
+        wrapper.unmount();
+    });
 });

--- a/src/components/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
+++ b/src/components/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
@@ -451,3 +451,196 @@ exports[`Dropdown should render correctly opened 1`] = `
   </List>
 </Dropdown>
 `;
+
+exports[`Dropdown should render correctly with mixed children: array and single ListItem 1`] = `
+<Dropdown
+  button={
+    <ForwardRef
+      context="brand"
+      disabled={false}
+      isBlock={false}
+      isInline={false}
+      size="normal"
+      type="button"
+    >
+      Click me!
+    </ForwardRef>
+  }
+  onChange={[MockFunction]}
+  placement="top-start"
+>
+  <Button
+    aria-expanded={true}
+    aria-haspopup="listbox"
+    aria-labelledby="downshift-41-label downshift-41-toggle-button"
+    context="brand"
+    disabled={false}
+    id="downshift-41-toggle-button"
+    isBlock={false}
+    isInline={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    size="normal"
+    type="button"
+  >
+    <button
+      aria-expanded={true}
+      aria-haspopup="listbox"
+      aria-labelledby="downshift-41-label downshift-41-toggle-button"
+      className="Button Button--context_brand"
+      disabled={false}
+      id="downshift-41-toggle-button"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      type="button"
+    >
+      Click me!
+    </button>
+  </Button>
+  <List
+    aria-labelledby="downshift-41-label"
+    className="Dropdown__list"
+    doSelectOnNavigate={false}
+    id="downshift-41-menu"
+    isControlledNavigation={true}
+    isDivided={false}
+    onBlur={[Function]}
+    onKeyDown={[Function]}
+    onMouseLeave={[Function]}
+    role="listbox"
+    style={
+      Object {
+        "left": "0",
+        "position": "absolute",
+        "top": "0",
+      }
+    }
+    tabIndex={-1}
+  >
+    <ul
+      aria-labelledby="downshift-41-label"
+      className="List Dropdown__list"
+      id="downshift-41-menu"
+      onBlur={[Function]}
+      onKeyDown={[Function]}
+      onMouseLeave={[Function]}
+      role="listbox"
+      style={
+        Object {
+          "left": "0",
+          "position": "absolute",
+          "top": "0",
+        }
+      }
+      tabIndex={-1}
+    >
+      <ListItem
+        className="List__item"
+        disabled={true}
+        highlightContext="default"
+        isHighlighted={false}
+        isSelected={false}
+        key=".$.$disabled-key"
+      >
+        <li
+          className="ListItem ListItem--disabled List__item"
+        >
+          <div
+            className="ListItem__container"
+            role="presentation"
+          >
+            <Text
+              context="default"
+              inline={true}
+              key=".0"
+              size="normal"
+            >
+              <span>
+                Disabled
+              </span>
+            </Text>
+          </div>
+        </li>
+      </ListItem>
+      <ListItem
+        aria-selected="false"
+        className="List__item"
+        disabled={false}
+        highlightContext="default"
+        id="downshift-41-item-0"
+        isHighlighted={false}
+        isSelected={false}
+        key=".$.1=2$one"
+        onClick={[Function]}
+        onMouseMove={[Function]}
+        role="option"
+        value="one"
+      >
+        <li
+          aria-selected="false"
+          className="ListItem ListItem--clickable List__item"
+          id="downshift-41-item-0"
+          onMouseMove={[Function]}
+          role="option"
+        >
+          <div
+            className="ListItem__container"
+            onClick={[Function]}
+            role="presentation"
+          >
+            <Text
+              context="default"
+              inline={true}
+              key=".0"
+              size="normal"
+            >
+              <span>
+                one
+              </span>
+            </Text>
+          </div>
+        </li>
+      </ListItem>
+      <ListItem
+        aria-selected="false"
+        className="List__item"
+        disabled={false}
+        highlightContext="default"
+        id="downshift-41-item-1"
+        isHighlighted={false}
+        isSelected={false}
+        key=".$.1=2$two"
+        onClick={[Function]}
+        onMouseMove={[Function]}
+        role="option"
+        value="two"
+      >
+        <li
+          aria-selected="false"
+          className="ListItem ListItem--clickable List__item"
+          id="downshift-41-item-1"
+          onMouseMove={[Function]}
+          role="option"
+        >
+          <div
+            className="ListItem__container"
+            onClick={[Function]}
+            role="presentation"
+          >
+            <Text
+              context="default"
+              inline={true}
+              key=".0"
+              size="normal"
+            >
+              <span>
+                two
+              </span>
+            </Text>
+          </div>
+        </li>
+      </ListItem>
+    </ul>
+  </List>
+</Dropdown>
+`;

--- a/stories/Dropdown.tsx
+++ b/stories/Dropdown.tsx
@@ -48,6 +48,9 @@ storiesOf('Molecules|Dropdown', module)
             ];
 
             const buttonIndex = select('customButton', [0, 1, 2], 0);
+
+            const customValues = ['ListItem with value 1', 'ListItem with value 2'];
+
             return (
                 <div style={styles.content}>
                     <Dropdown<string>
@@ -62,6 +65,11 @@ storiesOf('Molecules|Dropdown', module)
                         <ListItem key="first-key" value="first-value">
                             ListItem with value
                         </ListItem>
+                        {customValues.map((value) => (
+                            <ListItem key={value} value={value}>
+                                {value}
+                            </ListItem>
+                        ))}
                         <ListItem key="second-key" value="second-value">
                             <div style={styles.customListItem}>
                                 <IconTextkernel context="brand" style={styles.icon} />


### PR DESCRIPTION
The problem was in `children` prop type for Dropdown if you add as children mix of ListItem[] and single ListItem.
Example **(type error)**:
```
<Dropdown
    button={<Button context="brand">Click me!</Button>}
    onChange={mockOnChange}
    placement="top-start"
>
   <ListItem key="disabled-key" disabled>
      Disabled
   </ListItem>
   {['one', 'two'].map((value) => (
      <ListItem key={value} value={value}>
         {value}
      </ListItem>
   ))}
</Dropdown>
```

At the same type **no error** for:
```
<Dropdown
    button={<Button context="brand">Click me!</Button>}
    onChange={mockOnChange}
    placement="top-start"
>
   <ListItem key="disabled-key" disabled>
      Disabled
   </ListItem>
   <ListItem key="disabled-key-2" disabled>
      Disabled2
   </ListItem>
</Dropdown>
```
or
```
<Dropdown
    button={<Button context="brand">Click me!</Button>}
    onChange={mockOnChange}
    placement="top-start"
>
   {['one', 'two'].map((value) => (
      <ListItem key={value} value={value}>
         {value}
      </ListItem>
   ))}
</Dropdown>
```

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
