### PR TITLE
fix(MarkedText): fix issue with escaping of 's' character

### DIFF
--- a/src/components/Text/MarkedText/MarkedText.js
+++ b/src/components/Text/MarkedText/MarkedText.js
@@ -11,7 +11,7 @@ export const MarkedText = (props) => {
 
     let result = children;
     if (marker) {
-        const escapedMarker = marker.replace(/[-[\]{}()*+?.,\\^$|#\\s]/g, '\\$&');
+        const escapedMarker = marker.replace(/[-[\]{}()*+?.,\\^$|#]/g, '\\$&');
         const re = new RegExp(`(${escapedMarker})`, 'gi');
         result = children.split(re).map((part, i) =>
             part.toLowerCase() === marker.toLowerCase() ? (

--- a/src/components/Text/MarkedText/MarkedText.js
+++ b/src/components/Text/MarkedText/MarkedText.js
@@ -11,7 +11,7 @@ export const MarkedText = (props) => {
 
     let result = children;
     if (marker) {
-        const escapedMarker = marker.replace(/[-[\]{}()*+?.,\\^$|#]/g, '\\$&');
+        const escapedMarker = marker.replace(/[-[\]{}()*+?.,^$|#]/g, '\\$&');
         const re = new RegExp(`(${escapedMarker})`, 'gi');
         result = children.split(re).map((part, i) =>
             part.toLowerCase() === marker.toLowerCase() ? (

--- a/src/components/Text/MarkedText/__tests__/MarkedText.spec.js
+++ b/src/components/Text/MarkedText/__tests__/MarkedText.spec.js
@@ -24,6 +24,14 @@ describe('<MarkedText> that renders a text block while marking matched substring
         expect(toJson(wrapper)).toMatchSnapshot();
         expect(wrapper.find('mark')).toHaveLength(3);
     });
+    it('should mark special characters', () => {
+        const wrapper = mount(
+            // eslint-disable-next-line react/no-unescaped-entities
+            <MarkedText marker=".?!#$%^&()[]:;\?''">.?!#$%^&()[]:;\?''</MarkedText>
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(wrapper.find('mark')).toHaveLength(1);
+    });
     it('should pass props to Text', () => {
         const wrapper = mount(
             <MarkedText marker="text" inline context="brand">

--- a/src/components/Text/MarkedText/__tests__/__snapshots__/MarkedText.spec.js.snap
+++ b/src/components/Text/MarkedText/__tests__/__snapshots__/MarkedText.spec.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<MarkedText> that renders a text block while marking matched substrings should mark special characters 1`] = `
+<MarkedText
+  marker=".?!#$%^&()[]:;\\\\?''"
+>
+  <Text
+    context="default"
+    inline={false}
+    size="normal"
+  >
+    <p>
+      <mark
+        className="MarkedText__marked"
+        key="match0"
+      >
+        .?!#$%^&()[]:;\\?''
+      </mark>
+    </p>
+  </Text>
+</MarkedText>
+`;
+
 exports[`<MarkedText> that renders a text block while marking matched substrings should pass props to Text 1`] = `
 <MarkedText
   context="brand"


### PR DESCRIPTION
[ONEUI-263](https://jira.textkernel.nl/browse/ONEUI-263)

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
