### PR TITLE
feat(Dropdown): add Dropdown improvements

### DIFF
--- a/src/components/ButtonGroup/__tests__/ButtonGroup.spec.js
+++ b/src/components/ButtonGroup/__tests__/ButtonGroup.spec.js
@@ -31,8 +31,12 @@ describe('<ButtonGroup> that renders a button', () => {
             <ButtonGroup size="large" isBlock>
                 <Button>A button</Button>
                 <Button href="#">An anchor</Button>
-                <Dropdown button={<Button>A dropdown button</Button>} placement="bottom-end">
-                    <ListItem key="some-key">A list item</ListItem>
+                <Dropdown
+                    items={['']}
+                    button={<Button>A dropdown button</Button>}
+                    placement="bottom-end"
+                >
+                    {() => <ListItem>With value</ListItem>}
                 </Dropdown>
             </ButtonGroup>
         );

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.js.snap
@@ -161,12 +161,16 @@ exports[`<ButtonGroup> that renders a button should support mixed element types 
       }
       className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--last"
       context="neutral"
+      items={
+        Array [
+          "",
+        ]
+      }
       key=".2"
       placement="bottom-end"
       size="large"
     >
       <Button
-        aria-expanded={false}
         aria-haspopup="listbox"
         aria-labelledby="downshift-0-label downshift-0-toggle-button"
         className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--last"
@@ -181,7 +185,6 @@ exports[`<ButtonGroup> that renders a button should support mixed element types 
         type="button"
       >
         <button
-          aria-expanded={false}
           aria-haspopup="listbox"
           aria-labelledby="downshift-0-label downshift-0-toggle-button"
           className="Button Button--context_neutral Button--size_large ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_neutral ButtonGroup__button--last"

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,45 +1,67 @@
 import React, { useState } from 'react';
-import { useSelect } from 'downshift';
+import { useSelect, PropGetters } from 'downshift';
 import { usePopper } from 'react-popper';
 import { bem } from '../../utils/bem/bem';
 import { mergeRefs } from '../../utils/mergeRefs';
 import { PopupPlacement } from '../../constants';
 import { ButtonProps } from '../Buttons';
-import { ListItemProps } from '../List/ListItem';
 import { List } from '../List';
 import styles from './Dropdown.scss';
 
 const { elem } = bem('Dropdown', styles);
 
+export type DropdownRenderArgs<V> = {
+    getItemPropsByIndex: (index: number) => PropGetters<V>;
+};
+
 interface Props<V> extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
-    /**
-     *  Popup content to be placed inside List.
-     *  Navigation available only if element has not empty `value` attribute
-     *  and empty/false `disabled` attribute.
-     *  Use {@link ListItem} component.
-     */
-    children:
-        | React.ReactElement<ListItemProps>
-        | React.ReactElement<ListItemProps>[]
-        | (React.ReactElement<ListItemProps> | React.ReactElement<ListItemProps>[])[];
+    /** List of items */
+    items: V[];
+    /** Popup content */
+    children: (args: DropdownRenderArgs<V>) => React.ReactElement;
     /** {@link Button} element, controlled by current component */
     button: React.FunctionComponentElement<ButtonProps>;
-    /**
-     * Callback called on selecting one of the passed as children items.
-     * Value parameter it is a `value` attribute of children item ({@link ListItemProps.value}).
-     */
+    /** onChange called when an item is selected */
     onChange: (value: V) => void;
+    /** onOpen called on request to be open */
+    onOpen?: () => void;
+    /** onClose called on request to be close */
+    onClose?: () => void;
+    /** Should the children be shown. This prop is used when we need to have Dropdown as "controlled" component */
+    isOpen?: boolean;
+    /**
+     * Convert item to string.
+     * Prop is required if passed items are not list of strings.
+     * This is need for accessibility aria-live messages for downshift.
+     */
+    itemToString?: (item: V | null) => string;
     /** Popup placement relative to button */
     placement?: PopupPlacement;
 }
 
 /**
  * Component is intended for displaying available actions by button click.
- * It allows you to navigate with keyboard across non-disabled actions.
+ * It allows you to navigate with keyboard across actions.
  * If you don't need navigation - use PopupBase component.
  */
 export function Dropdown<V>(props: Props<V>) {
-    const { button, children, onChange, placement, ...rest } = props;
+    const {
+        button,
+        children,
+        items,
+        onChange,
+        onOpen,
+        onClose,
+        isOpen: isOpenProp,
+        itemToString,
+        placement,
+        ...rest
+    } = props;
+
+    // Assuming the rest of the items have the same type as the first item
+    if (items[0] && typeof items[0] !== 'string' && itemToString === undefined) {
+        throw new Error('You need pass "itemToString" for non string "items"');
+    }
 
     const [referenceElement, setReferenceElement] = useState(null);
     const [popperElement, setPopperElement] = useState(null);
@@ -54,19 +76,6 @@ export function Dropdown<V>(props: Props<V>) {
         ],
     });
 
-    const childrenArray = React.Children.toArray(children);
-    const valuesAvailableForHighlight: V[] = [];
-    childrenArray.forEach((child: NotEmptyReactNode) => {
-        if (
-            React.isValidElement(child) &&
-            child.props.value !== undefined &&
-            child.props.value !== null &&
-            !child.props.disabled
-        ) {
-            valuesAvailableForHighlight.push(child.props.value);
-        }
-    });
-
     const {
         isOpen,
         getItemProps,
@@ -75,11 +84,22 @@ export function Dropdown<V>(props: Props<V>) {
         highlightedIndex,
         reset,
     } = useSelect<V>({
-        items: valuesAvailableForHighlight,
+        items,
+        isOpen: isOpenProp,
+        itemToString,
         onSelectedItemChange: ({ selectedItem }) => {
             if (selectedItem) {
                 onChange(selectedItem);
                 reset();
+            }
+        },
+        onIsOpenChange: (changes) => {
+            if (changes.isOpen) {
+                if (onOpen) {
+                    onOpen();
+                }
+            } else if (onClose) {
+                onClose();
             }
         },
     });
@@ -91,6 +111,16 @@ export function Dropdown<V>(props: Props<V>) {
         ...state.attributes.popper,
         ...elem('list'),
     };
+    const getItemPropsByIndex = (index: number) => {
+        return {
+            ...getItemProps({
+                index,
+                item: items[index],
+            }),
+            isHighlighted: highlightedIndex === index,
+        };
+    };
+
     return (
         <>
             {React.cloneElement(button, {
@@ -104,26 +134,7 @@ export function Dropdown<V>(props: Props<V>) {
                 ref={mergeRefs([isOpen && setPopperElement, menuProps.ref])}
                 isControlledNavigation
             >
-                {isOpen &&
-                    childrenArray.map((child) => {
-                        if (
-                            React.isValidElement(child) &&
-                            valuesAvailableForHighlight.includes(child.props.value)
-                        ) {
-                            const currentValueIndex = valuesAvailableForHighlight.findIndex(
-                                (val) => val === child.props.value
-                            );
-
-                            return React.cloneElement(child, {
-                                ...getItemProps({
-                                    index: currentValueIndex,
-                                    item: child.props.value,
-                                }),
-                                isHighlighted: highlightedIndex === currentValueIndex,
-                            });
-                        }
-                        return child;
-                    })}
+                {isOpen && children({ getItemPropsByIndex })}
             </List>
         </>
     );
@@ -133,4 +144,8 @@ Dropdown.displayName = 'Dropdown';
 
 Dropdown.defaultProps = {
     placement: 'bottom-end',
+    onOpen: undefined,
+    onClose: undefined,
+    isOpen: undefined,
+    itemToString: undefined,
 };

--- a/src/components/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
+++ b/src/components/Dropdown/__tests__/__snapshots__/Dropdown.spec.js.snap
@@ -1,5 +1,213 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Dropdown isOpen should open and close list of items 1`] = `
+<Dropdown
+  button={
+    <ForwardRef
+      context="brand"
+      disabled={false}
+      isBlock={false}
+      isInline={false}
+      size="normal"
+      type="button"
+    >
+      Click me!
+    </ForwardRef>
+  }
+  isOpen={true}
+  items={
+    Array [
+      "testValue",
+    ]
+  }
+  onChange={[MockFunction]}
+  placement="top-start"
+>
+  <Button
+    aria-expanded={true}
+    aria-haspopup="listbox"
+    aria-labelledby="downshift-50-label downshift-50-toggle-button"
+    context="brand"
+    disabled={false}
+    id="downshift-50-toggle-button"
+    isBlock={false}
+    isInline={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    size="normal"
+    type="button"
+  >
+    <button
+      aria-expanded={true}
+      aria-haspopup="listbox"
+      aria-labelledby="downshift-50-label downshift-50-toggle-button"
+      className="Button Button--context_brand"
+      disabled={false}
+      id="downshift-50-toggle-button"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      type="button"
+    >
+      Click me!
+    </button>
+  </Button>
+  <List
+    aria-labelledby="downshift-50-label"
+    className="Dropdown__list"
+    doSelectOnNavigate={false}
+    id="downshift-50-menu"
+    isControlledNavigation={true}
+    isDivided={false}
+    onBlur={[Function]}
+    onKeyDown={[Function]}
+    onMouseLeave={[Function]}
+    role="listbox"
+    style={
+      Object {
+        "left": "0",
+        "position": "absolute",
+        "top": "0",
+      }
+    }
+    tabIndex={-1}
+  >
+    <ul
+      aria-labelledby="downshift-50-label"
+      className="List Dropdown__list"
+      id="downshift-50-menu"
+      onBlur={[Function]}
+      onKeyDown={[Function]}
+      onMouseLeave={[Function]}
+      role="listbox"
+      style={
+        Object {
+          "left": "0",
+          "position": "absolute",
+          "top": "0",
+        }
+      }
+      tabIndex={-1}
+    >
+      <ListItem
+        aria-selected="false"
+        className="List__item"
+        disabled={false}
+        highlightContext="default"
+        id="downshift-50-item-0"
+        isHighlighted={false}
+        isSelected={false}
+        key=".0"
+        onClick={[Function]}
+        onMouseMove={[Function]}
+        role="option"
+      >
+        <li
+          aria-selected="false"
+          className="ListItem ListItem--clickable List__item"
+          id="downshift-50-item-0"
+          onMouseMove={[Function]}
+          role="option"
+        >
+          <div
+            className="ListItem__container"
+            onClick={[Function]}
+            role="presentation"
+          >
+            <Text
+              context="default"
+              inline={true}
+              key=".0"
+              size="normal"
+            >
+              <span>
+                With value
+              </span>
+            </Text>
+          </div>
+        </li>
+      </ListItem>
+    </ul>
+  </List>
+</Dropdown>
+`;
+
+exports[`Dropdown isOpen should open and close list of items 2`] = `
+<Dropdown
+  button={
+    <ForwardRef
+      context="brand"
+      disabled={false}
+      isBlock={false}
+      isInline={false}
+      size="normal"
+      type="button"
+    >
+      Click me!
+    </ForwardRef>
+  }
+  isOpen={false}
+  items={
+    Array [
+      "testValue",
+    ]
+  }
+  onChange={[MockFunction]}
+  placement="top-start"
+>
+  <Button
+    aria-expanded={false}
+    aria-haspopup="listbox"
+    aria-labelledby="downshift-50-label downshift-50-toggle-button"
+    context="brand"
+    disabled={false}
+    id="downshift-50-toggle-button"
+    isBlock={false}
+    isInline={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    size="normal"
+    type="button"
+  >
+    <button
+      aria-expanded={false}
+      aria-haspopup="listbox"
+      aria-labelledby="downshift-50-label downshift-50-toggle-button"
+      className="Button Button--context_brand"
+      disabled={false}
+      id="downshift-50-toggle-button"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      type="button"
+    >
+      Click me!
+    </button>
+  </Button>
+  <List
+    aria-labelledby="downshift-50-label"
+    doSelectOnNavigate={false}
+    id="downshift-50-menu"
+    isControlledNavigation={true}
+    isDivided={false}
+    onBlur={[Function]}
+    onKeyDown={[Function]}
+    onMouseLeave={[Function]}
+    role="listbox"
+    tabIndex={-1}
+  >
+    <ul
+      aria-labelledby="downshift-50-label"
+      className="List"
+      id="downshift-50-menu"
+      onBlur={[Function]}
+      onKeyDown={[Function]}
+      onMouseLeave={[Function]}
+      role="listbox"
+      tabIndex={-1}
+    />
+  </List>
+</Dropdown>
+`;
+
 exports[`Dropdown should downshift only by enabled items with value 1`] = `
 <Dropdown
   button={
@@ -13,6 +221,12 @@ exports[`Dropdown should downshift only by enabled items with value 1`] = `
     >
       Click me!
     </ForwardRef>
+  }
+  items={
+    Array [
+      "1",
+      "2",
+    ]
   }
   onChange={[MockFunction]}
   placement="top-start"
@@ -83,15 +297,13 @@ exports[`Dropdown should downshift only by enabled items with value 1`] = `
       tabIndex={-1}
     >
       <ListItem
-        className="List__item"
         disabled={true}
         highlightContext="default"
         isHighlighted={false}
         isSelected={false}
-        key=".$.$key-1"
       >
         <li
-          className="ListItem ListItem--disabled List__item"
+          className="ListItem ListItem--disabled"
         >
           <div
             className="ListItem__container"
@@ -112,21 +324,18 @@ exports[`Dropdown should downshift only by enabled items with value 1`] = `
       </ListItem>
       <ListItem
         aria-selected="false"
-        className="List__item"
         disabled={false}
         highlightContext="default"
         id="downshift-12-item-0"
         isHighlighted={false}
         isSelected={false}
-        key=".$.$key-2"
         onClick={[Function]}
         onMouseMove={[Function]}
         role="option"
-        value="1"
       >
         <li
           aria-selected="false"
-          className="ListItem ListItem--clickable List__item"
+          className="ListItem ListItem--clickable"
           id="downshift-12-item-0"
           onMouseMove={[Function]}
           role="option"
@@ -150,15 +359,13 @@ exports[`Dropdown should downshift only by enabled items with value 1`] = `
         </li>
       </ListItem>
       <ListItem
-        className="List__item"
         disabled={false}
         highlightContext="default"
         isHighlighted={false}
         isSelected={false}
-        key=".$.$key-3"
       >
         <li
-          className="ListItem List__item"
+          className="ListItem"
         >
           <div
             className="ListItem__container"
@@ -178,28 +385,24 @@ exports[`Dropdown should downshift only by enabled items with value 1`] = `
         </li>
       </ListItem>
       <div
-        className="List__item customDiv"
-        key=".$.$key-4"
+        className="customDiv"
       >
         Div
       </div>
       <ListItem
         aria-selected="false"
-        className="List__item"
         disabled={false}
         highlightContext="default"
         id="downshift-12-item-1"
         isHighlighted={false}
         isSelected={false}
-        key=".$.$key-5"
         onClick={[Function]}
         onMouseMove={[Function]}
         role="option"
-        value="2"
       >
         <li
           aria-selected="false"
-          className="ListItem ListItem--clickable List__item"
+          className="ListItem ListItem--clickable"
           id="downshift-12-item-1"
           onMouseMove={[Function]}
           role="option"
@@ -241,11 +444,15 @@ exports[`Dropdown should render correctly closed 1`] = `
       Click me!
     </ForwardRef>
   }
+  items={
+    Array [
+      "first-value",
+    ]
+  }
   onChange={[MockFunction]}
   placement="top-start"
 >
   <Button
-    aria-expanded={false}
     aria-haspopup="listbox"
     aria-labelledby="downshift-0-label downshift-0-toggle-button"
     context="brand"
@@ -259,7 +466,6 @@ exports[`Dropdown should render correctly closed 1`] = `
     type="button"
   >
     <button
-      aria-expanded={false}
       aria-haspopup="listbox"
       aria-labelledby="downshift-0-label downshift-0-toggle-button"
       className="Button Button--context_brand"
@@ -311,6 +517,11 @@ exports[`Dropdown should render correctly opened 1`] = `
     >
       Click me!
     </ForwardRef>
+  }
+  items={
+    Array [
+      "first-value",
+    ]
   }
   onChange={[MockFunction]}
   placement="top-start"
@@ -381,15 +592,13 @@ exports[`Dropdown should render correctly opened 1`] = `
       tabIndex={-1}
     >
       <ListItem
-        className="List__item"
         disabled={true}
         highlightContext="default"
         isHighlighted={false}
         isSelected={false}
-        key=".$.$disabled-key"
       >
         <li
-          className="ListItem ListItem--disabled List__item"
+          className="ListItem ListItem--disabled"
         >
           <div
             className="ListItem__container"
@@ -410,21 +619,18 @@ exports[`Dropdown should render correctly opened 1`] = `
       </ListItem>
       <ListItem
         aria-selected="false"
-        className="List__item"
         disabled={false}
         highlightContext="default"
         id="downshift-3-item-0"
         isHighlighted={false}
         isSelected={false}
-        key=".$.$first-key"
         onClick={[Function]}
         onMouseMove={[Function]}
         role="option"
-        value="first-value"
       >
         <li
           aria-selected="false"
-          className="ListItem ListItem--clickable List__item"
+          className="ListItem ListItem--clickable"
           id="downshift-3-item-0"
           onMouseMove={[Function]}
           role="option"
@@ -465,6 +671,12 @@ exports[`Dropdown should render correctly with mixed children: array and single 
     >
       Click me!
     </ForwardRef>
+  }
+  items={
+    Array [
+      "one",
+      "two",
+    ]
   }
   onChange={[MockFunction]}
   placement="top-start"
@@ -535,15 +747,13 @@ exports[`Dropdown should render correctly with mixed children: array and single 
       tabIndex={-1}
     >
       <ListItem
-        className="List__item"
         disabled={true}
         highlightContext="default"
         isHighlighted={false}
         isSelected={false}
-        key=".$.$disabled-key"
       >
         <li
-          className="ListItem ListItem--disabled List__item"
+          className="ListItem ListItem--disabled"
         >
           <div
             className="ListItem__container"
@@ -564,21 +774,19 @@ exports[`Dropdown should render correctly with mixed children: array and single 
       </ListItem>
       <ListItem
         aria-selected="false"
-        className="List__item"
         disabled={false}
         highlightContext="default"
         id="downshift-41-item-0"
         isHighlighted={false}
         isSelected={false}
-        key=".$.1=2$one"
+        key="one"
         onClick={[Function]}
         onMouseMove={[Function]}
         role="option"
-        value="one"
       >
         <li
           aria-selected="false"
-          className="ListItem ListItem--clickable List__item"
+          className="ListItem ListItem--clickable"
           id="downshift-41-item-0"
           onMouseMove={[Function]}
           role="option"
@@ -603,21 +811,19 @@ exports[`Dropdown should render correctly with mixed children: array and single 
       </ListItem>
       <ListItem
         aria-selected="false"
-        className="List__item"
         disabled={false}
         highlightContext="default"
         id="downshift-41-item-1"
         isHighlighted={false}
         isSelected={false}
-        key=".$.1=2$two"
+        key="two"
         onClick={[Function]}
         onMouseMove={[Function]}
         role="option"
-        value="two"
       >
         <li
           aria-selected="false"
-          className="ListItem ListItem--clickable List__item"
+          className="ListItem ListItem--clickable"
           id="downshift-41-item-1"
           onMouseMove={[Function]}
           role="option"

--- a/src/components/Dropdown/index.ts
+++ b/src/components/Dropdown/index.ts
@@ -1,1 +1,1 @@
-export { Dropdown } from './Dropdown';
+export { Dropdown, DropdownRenderArgs } from './Dropdown';

--- a/src/components/List/ListItem/ListItem.tsx
+++ b/src/components/List/ListItem/ListItem.tsx
@@ -19,8 +19,6 @@ export interface Props extends Omit<React.HTMLAttributes<HTMLLIElement>, 'onClic
     highlightContext?: Context | 'default';
     /** Ref to access the li element */
     ref?: React.RefObject<HTMLLIElement>;
-    /** Item identifier is used in {@link Dropdown} to select/navigate through children */
-    value?: unknown;
 }
 
 const { block, elem } = bem('ListItem', styles);
@@ -33,7 +31,6 @@ export const ListItem: React.FC<Props> = React.forwardRef((props, ref) => {
         onClick,
         disabled,
         highlightContext,
-        value,
         ...rest
     } = props;
     const customBlockMod = { clickable: typeof onClick === 'function' };

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export { Alert } from './components/Alert';
 export * from './components/BulkActionsToolbar';
 export { ButtonGroup } from './components/ButtonGroup';
 export { Checkbox } from './components/Checkbox';
-export { Dropdown } from './components/Dropdown';
+export { Dropdown, DropdownRenderArgs } from './components/Dropdown';
 export { Footer } from './components/Footer';
 export { Header } from './components/Header';
 export { Gauge } from './components/Gauge';

--- a/stories/Dropdown.tsx
+++ b/stories/Dropdown.tsx
@@ -18,7 +18,7 @@ const styles = {
         height: '40px',
         justifyContent: 'center',
     },
-    customListItem: {
+    listItem: {
         alignItems: 'center',
         display: 'flex',
     },
@@ -32,65 +32,61 @@ const styles = {
 
 storiesOf('Molecules|Dropdown', module)
     .addDecorator(withKnobs)
-    .add(
-        'Dropdown',
-        () => {
-            const onChange = (value) => {
-                console.log(`onChange was called value : ${value}`);
-            };
+    .add('Dropdown', () => {
+        const onChange = (value) => {
+            console.log(`onChange was called value : ${value}`);
+        };
+        const onOpen = () => {
+            console.log('Dropdown was requested to be open.');
+        };
+        const onClose = () => {
+            console.log('Dropdown was requested to be close.');
+        };
 
-            const customButtonsDemo = [
-                <Button context="brand">Click me!</Button>,
-                <Button context="neutral">
-                    <HiDotsVertical />
-                </Button>,
-                <Button context="link">Select any</Button>,
-            ];
+        const customButtonsDemo = [
+            <Button context="brand">Click me!</Button>,
+            <Button context="neutral">
+                <HiDotsVertical />
+            </Button>,
+            <Button context="link">Select any</Button>,
+        ];
 
-            const buttonIndex = select('customButton', [0, 1, 2], 0);
+        const buttonIndex = select('customButton', [0, 1, 2], 0);
 
-            const customValues = ['ListItem with value 1', 'ListItem with value 2'];
+        const customValues = [
+            'ListItem with value 1',
+            'ListItem with value 2',
+            'ListItem with value 3',
+        ];
 
-            return (
-                <div style={styles.content}>
-                    <Dropdown<string>
-                        style={{ width: 'fit-content' }}
-                        button={customButtonsDemo[buttonIndex]}
-                        onChange={onChange}
-                        placement={select('placement', POPUP_PLACEMENTS, 'bottom-end')}
-                    >
-                        <ListItem key="disabled-key" disabled style={styles.divider}>
-                            Disabled ListItem
-                        </ListItem>
-                        <ListItem key="first-key" value="first-value">
-                            ListItem with value
-                        </ListItem>
-                        {customValues.map((value) => (
-                            <ListItem key={value} value={value}>
-                                {value}
-                            </ListItem>
-                        ))}
-                        <ListItem key="second-key" value="second-value">
-                            <div style={styles.customListItem}>
-                                <IconTextkernel context="brand" style={styles.icon} />
-                                <strong>Custom ListItem with value</strong>
-                            </div>
-                        </ListItem>
-                        <div style={styles.customDiv}>Just custom div element</div>
-                    </Dropdown>
-                </div>
-            );
-        },
-        {
-            info: {
-                text: `
-                ## Usage information
-                 
-                Navigation available only through children which have not empty \`value\` attribute
-                and empty/false \`disabled\` attribute (all other children items will be skipped during navigation).
-                
-                Use \`ListItem\` component as child item.
-                `,
-            },
-        }
-    );
+        return (
+            <div style={styles.content}>
+                <Dropdown<string>
+                    items={customValues}
+                    style={{ width: 'fit-content' }}
+                    button={customButtonsDemo[buttonIndex]}
+                    onChange={onChange}
+                    onOpen={onOpen}
+                    onClose={onClose}
+                    placement={select('placement', POPUP_PLACEMENTS, 'bottom-end')}
+                >
+                    {({ getItemPropsByIndex }) => {
+                        return (
+                            <>
+                                <ListItem disabled>Disabled</ListItem>
+                                {customValues.map((value, index) => (
+                                    <ListItem key={value} {...getItemPropsByIndex(index)}>
+                                        <div style={styles.listItem}>
+                                            <IconTextkernel context="brand" style={styles.icon} />
+                                            {value}
+                                        </div>
+                                    </ListItem>
+                                ))}
+                                <div style={styles.customDiv}>Just custom div element</div>
+                            </>
+                        );
+                    }}
+                </Dropdown>
+            </div>
+        );
+    });


### PR DESCRIPTION
BREAKING CHANGE: Dropdown children is a function instead of component. Introduced new props `items`, `onOpen`, `onClose`, `isOpen`, `itemToString` in favor to make Dropdown as controlled component.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. Use imperative, present tense in your commit description ("change", not "changed" or "changes") without uppercases or period (.) at the end.

# Checklist
- [ ] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
