### PR TITLE
feat(LocationSelector): add prop to set different input placeholder inside the modal

### DIFF
--- a/src/components/LocationSelector/LocationSelector.tsx
+++ b/src/components/LocationSelector/LocationSelector.tsx
@@ -66,6 +66,8 @@ interface Props {
     modalContentLabel: string;
     /** placeholder for both main field and autocomplete field in modal */
     inputPlaceholder: string;
+    /** placeholder for autocomplete field inside the modal. If not given inputPlaceholder will be used */
+    modalInputPlaceholder?: string;
     /** placeholder for empty LocationAutocomplete list */
     noSuggestionsPlaceholder: string;
     /** function to be executed if error occurs while fetching suggestions */
@@ -115,6 +117,7 @@ export const LocationSelector: React.FC<Props> = (props) => {
         doneLabel,
 
         /** LocationAutocomplete props */
+        modalInputPlaceholder,
         country,
         initialMapAddress,
         placeTypes,
@@ -265,7 +268,7 @@ export const LocationSelector: React.FC<Props> = (props) => {
                     language={language}
                     region={region}
                     {...additionalGoogleProps}
-                    inputPlaceholder={inputPlaceholder}
+                    inputPlaceholder={modalInputPlaceholder || inputPlaceholder}
                     hasRadius={hasRadius}
                     minRadius={minRadius}
                     maxRadius={maxRadius}

--- a/src/components/LocationSelector/LocationSelectorDialog/LocationSelectorDialog.js
+++ b/src/components/LocationSelector/LocationSelectorDialog/LocationSelectorDialog.js
@@ -195,7 +195,7 @@ LocationSelectorDialog.propTypes = {
     placeTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
     /** show country name in autocomplete suggestions */
     showCountryInSuggestions: PropTypes.bool,
-    /** placeholder for both main field and autocomplete field in modal */
+    /** placeholder for autocomplete field */
     inputPlaceholder: PropTypes.string.isRequired,
     /** placeholder for empty LocationAutocomplete list */
     noSuggestionsPlaceholder: PropTypes.string.isRequired,

--- a/stories/LocationSelector.tsx
+++ b/stories/LocationSelector.tsx
@@ -55,6 +55,7 @@ storiesOf('Organisms|LocationSelector', module)
                     'Location selection'
                 )}
                 inputPlaceholder={text('Input placeholder', 'Location...')}
+                modalInputPlaceholder={text('Input placeholder inside the modal', '')}
                 noSuggestionsPlaceholder="noSuggestionsPlaceholder"
                 selectionPlaceholder="selectionPlaceholder"
                 doneLabel={text('Label for Done button', 'Done')}
@@ -136,6 +137,7 @@ storiesOf('Organisms|LocationSelector', module)
                     'Location selection'
                 )}
                 inputPlaceholder={text('Input placeholder', 'Location...')}
+                modalInputPlaceholder={text('Input placeholder inside the modal', '')}
                 noSuggestionsPlaceholder="noSuggestionsPlaceholder"
                 selectionPlaceholder={getPlaceholder()}
                 doneLabel={text('Label for Done button', 'Done')}
@@ -217,6 +219,7 @@ storiesOf('Organisms|LocationSelector', module)
                     'Location selection'
                 )}
                 inputPlaceholder={text('Input placeholder', 'Location...')}
+                modalInputPlaceholder={text('Input placeholder inside the modal', '')}
                 noSuggestionsPlaceholder="noSuggestionsPlaceholder"
                 selectionPlaceholder={getPlaceholder()}
                 doneLabel={text('Label for Done button', 'Done')}


### PR DESCRIPTION
Story: [JF-2714](https://jira.textkernel.nl/browse/JF-2714)

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. Use imperative, present tense in your commit description ("change", not "changed" or "changes") without uppercases or period (.) at the end.

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
