### PR TITLE
feat(Tabs): allow passing custom TS types

### DIFF
--- a/src/components/Tabs/TabItem/TabItem.tsx
+++ b/src/components/Tabs/TabItem/TabItem.tsx
@@ -3,15 +3,15 @@ import { bem } from '../../../utils';
 import { ENTER_KEY } from '../../../constants';
 import styles from './TabItem.scss';
 
-export interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+export interface Props<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
     /** Id of this tab */
-    tabId: string | number;
+    tabId: T;
     /** Renders an active tab. This prop will be set by TabsBar if activeTabId is defined there */
     isActive?: boolean;
     /** Disabled tab item */
     disabled?: boolean;
     /** A callback  when the tab is clicked. It will not be called for active or disabled tabs. This prop will be set by TabsBar if onSelect is defined there */
-    onSelect?: (tabId: string | number) => void;
+    onSelect?: (tabId: T) => void;
     /** Label of the tab. Expected to be a string like node. E.g. `label` or `label <span>(3)</span>`  */
     children: ReactNode;
     /** used for styling when TabsBar is full width. Will be set by TabsBar, no need to set manually */
@@ -20,7 +20,7 @@ export interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSel
 
 const { block } = bem('TabItem', styles);
 
-export const TabItem: React.FC<Props> = (props) => {
+export function TabItem<T = string | number>(props: Props<T>) {
     const { tabId, isActive, onSelect, disabled, isBlock, children, ...rest } = props;
     const handleClick = () => {
         if (!isActive && !disabled && onSelect) {
@@ -47,7 +47,7 @@ export const TabItem: React.FC<Props> = (props) => {
             {children}
         </div>
     );
-};
+}
 
 TabItem.displayName = 'TabItem';
 

--- a/src/components/Tabs/TabsBar/TabsBar.tsx
+++ b/src/components/Tabs/TabsBar/TabsBar.tsx
@@ -3,32 +3,32 @@ import { bem } from '../../../utils';
 import { TabItem, TabItemProps } from '../TabItem';
 import styles from './TabsBar.scss';
 
-interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+interface Props<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
     /** Id of currently active tab. This will overwrite isActive on the children */
-    activeTabId?: string | number;
+    activeTabId?: T;
     /** The tabs */
-    children: React.ReactElement<TabItemProps> | React.ReactElement<TabItemProps>[];
+    children: React.ReactElement<TabItemProps<T>> | React.ReactElement<TabItemProps<T>>[];
     /** Callback function, fired when switching tabs by clicking. This will overwrite onSelect on children, if defined */
-    onSelect?: (selectedTabId: number | string) => void;
+    onSelect?: (selectedTabId: T) => void;
     /** to render the tabs so they cover the full width of the available space */
     isBlock?: boolean;
 }
 
-interface PropsToPassToChild {
+interface PropsToPassToChild<T> {
     isActive?: boolean;
-    onSelect?: Props['onSelect'];
-    isBlock?: Props['isBlock'];
+    onSelect?: Props<T>['onSelect'];
+    isBlock?: Props<T>['isBlock'];
 }
 
 const { block } = bem('TabsBar', styles);
 
-export const TabsBar: React.FC<Props> = (props) => {
+export function TabsBar<T = string | number>(props: Props<T>) {
     const { activeTabId, children, onSelect, isBlock, ...rest } = props;
 
-    const extendWithProps = (tab: Props['children']) => {
+    const extendWithProps = (tab: Props<T>['children']) => {
         if (React.isValidElement(tab) && tab.type === TabItem) {
             const { tabId } = tab.props;
-            const extendProps: PropsToPassToChild = { isBlock };
+            const extendProps: PropsToPassToChild<T> = { isBlock };
             if (activeTabId) {
                 extendProps.isActive = tabId === activeTabId;
             }
@@ -48,10 +48,12 @@ export const TabsBar: React.FC<Props> = (props) => {
                 : children}
         </div>
     );
-};
+}
 
 TabsBar.displayName = 'TabsBar';
 
 TabsBar.defaultProps = {
     isBlock: false,
+    activeTabId: undefined,
+    onSelect: undefined,
 };

--- a/stories/Tabs.tsx
+++ b/stories/Tabs.tsx
@@ -66,30 +66,31 @@ storiesOf('Atoms|Tabs', module)
             </TabsBar>
         );
     })
-    .add('Example implementation', (parameters) => {
-        const store = parameters?.parameters.getStore();
+    .add('Example implementation', () => {
+        type Tabs = 't1' | 't2' | 't3';
+        const [activeId, setActiveId] = React.useState<Tabs>('t1');
 
-        const handleSelect = (tabId) => {
+        const handleSelect = (tabId: Tabs) => {
             // IE11 errors on string concatenation inside console.log. So let's do it outside of it.
             const msg = `TabItem with tabId: '${tabId}' was clicked`;
             console.log(msg);
-            store.set({ activeId: tabId });
+            setActiveId(tabId);
         };
 
         return (
-            <TabsBar
-                activeTabId={store.get('activeId')}
+            <TabsBar<Tabs>
+                activeTabId={activeId}
                 onSelect={handleSelect}
                 isBlock={boolean('Equally spaced items', false)}
             >
-                <TabItem tabId={1} key={1} disabled={boolean('Tab 1 is disabled', false)}>
+                <TabItem tabId="t1" key={1} disabled={boolean('Tab 1 is disabled', false)}>
                     {text('Tab 1 label', 'Simple tab')}
                 </TabItem>
-                <TabItem tabId={2} key={2} disabled={boolean('Tab 2 is disabled', false)}>
+                <TabItem tabId="t2" key={2} disabled={boolean('Tab 2 is disabled', false)}>
                     {text('Tab 2 label', 'Tab with styled count')}
                     <span style={{ color: 'grey', fontWeight: 400 }}> (2)</span>
                 </TabItem>
-                <TabItem tabId={3} key={3} disabled={boolean('Tab 3 is disabled', false)}>
+                <TabItem tabId="t3" key={3} disabled={boolean('Tab 3 is disabled', false)}>
                     <Tooltip content="some additional information" placement="top">
                         <div>{text('Tab 3 label', 'Tab with Tooltip')}</div>
                     </Tooltip>


### PR DESCRIPTION
Improve TS typing in Tab components to allow specifying possible tab ids instead of generic `number | string`

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
