### PR TITLE
feat(SelectButtonGroup): add support for controlled behavior and improve API

### DIFF
--- a/src/components/SelectButtonGroup/SelectButton/SelectButton.scss
+++ b/src/components/SelectButtonGroup/SelectButton/SelectButton.scss
@@ -33,7 +33,7 @@
         cursor: not-allowed;
     }
 
-    &--isSelected.SelectButton--selectedContext_neutral {
+    &--isSelected.SelectButton--context_neutral {
         border-color: var(--color-neutral-60);
         background-color: var(--color-neutral-60);
         color: var(--color-background);
@@ -45,7 +45,7 @@
         }
     }
 
-    &--isSelected.SelectButton--selectedContext {
+    &--isSelected.SelectButton--context {
         @each $context in (brand, primary, accent, info, good, warning, bad) {
             &_#{$context} {
                 border-color: var(--color-#{$context});

--- a/src/components/SelectButtonGroup/SelectButton/SelectButton.tsx
+++ b/src/components/SelectButtonGroup/SelectButton/SelectButton.tsx
@@ -18,7 +18,7 @@ export interface Props<V> extends InternalProps<V> {
     children: NotEmptyReactNode;
     /** the value associated with this button */
     value: V;
-    /** if this button should be in a selected when first rendered */
+    /** whether or not this button is selected */
     isSelected?: boolean;
     /** the color context to be applied in the selected state */
     context?: Context;

--- a/src/components/SelectButtonGroup/SelectButton/SelectButton.tsx
+++ b/src/components/SelectButtonGroup/SelectButton/SelectButton.tsx
@@ -29,11 +29,13 @@ export interface Props<V> extends InternalProps<V> {
 const { block } = bem('SelectButton', styles);
 
 export function SelectButton<V>(props: Props<V>) {
-    const { children, value, onChange, isEqualWidth, isBlock, context, isSelected, ...rest } =
+    const { children, value, onChange, isEqualWidth, isBlock, context, isSelected, size, ...rest } =
         props;
 
     const handleClick = () => {
-        onChange?.(value);
+        if (onChange) {
+            onChange(value);
+        }
     };
 
     const handleKeyPress = (e: React.KeyboardEvent<HTMLDivElement>) => {

--- a/src/components/SelectButtonGroup/SelectButton/SelectButton.tsx
+++ b/src/components/SelectButtonGroup/SelectButton/SelectButton.tsx
@@ -5,8 +5,6 @@ import styles from './SelectButton.scss';
 
 // These props will be passed by the parent <SelectButtonGroup>
 interface InternalProps<V> extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
-    /** if this button should be in a selected state */
-    isSelected?: boolean;
     /** A function to be called if a button is pressed. */
     onChange?: (value: V) => void;
     /** If this component a child of a full block with container  */
@@ -21,9 +19,9 @@ export interface Props<V> extends InternalProps<V> {
     /** the value associated with this button */
     value: V;
     /** if this button should be in a selected when first rendered */
-    isInitiallySelected?: boolean;
+    isSelected?: boolean;
     /** the color context to be applied in the selected state */
-    selectedContext?: Context;
+    context?: Context;
     /** size of the button */
     size?: Size;
 }
@@ -31,17 +29,8 @@ export interface Props<V> extends InternalProps<V> {
 const { block } = bem('SelectButton', styles);
 
 export function SelectButton<V>(props: Props<V>) {
-    const {
-        children,
-        value,
-        onChange,
-        isEqualWidth,
-        isBlock,
-        selectedContext,
-        isInitiallySelected,
-        isSelected,
-        ...rest
-    } = props;
+    const { children, value, onChange, isEqualWidth, isBlock, context, isSelected, ...rest } =
+        props;
 
     const handleClick = () => {
         onChange?.(value);
@@ -70,7 +59,8 @@ export function SelectButton<V>(props: Props<V>) {
 SelectButton.displayName = 'SelectButton';
 
 SelectButton.defaultProps = {
-    isInitiallySelected: false,
+    context: 'brand',
+    isSelected: false,
     isEqualWidth: false,
     size: 'normal',
 };

--- a/src/components/SelectButtonGroup/SelectButton/__tests__/SelectButton.spec.js
+++ b/src/components/SelectButtonGroup/SelectButton/__tests__/SelectButton.spec.js
@@ -9,7 +9,14 @@ describe('SelectButton', () => {
 
     beforeEach(() => {
         wrapper = mount(
-            <SelectButton value="button 1" onChange={onChangeMock}>
+            <SelectButton
+                value="button 1"
+                onChange={onChangeMock}
+                context="good"
+                size="large"
+                isEqualWidth
+                isSelected
+            >
                 Option 1
             </SelectButton>
         );

--- a/src/components/SelectButtonGroup/SelectButton/__tests__/__snapshots__/SelectButton.spec.js.snap
+++ b/src/components/SelectButtonGroup/SelectButton/__tests__/__snapshots__/SelectButton.spec.js.snap
@@ -2,14 +2,15 @@
 
 exports[`SelectButton should render correctly 1`] = `
 <SelectButton
+  context="brand"
   isEqualWidth={false}
-  isInitiallySelected={false}
+  isSelected={false}
   onChange={[MockFunction]}
   size="normal"
   value="button 1"
 >
   <div
-    className="SelectButton"
+    className="SelectButton SelectButton--context_brand"
     onClick={[Function]}
     onKeyPress={[Function]}
     role="button"

--- a/src/components/SelectButtonGroup/SelectButton/__tests__/__snapshots__/SelectButton.spec.js.snap
+++ b/src/components/SelectButtonGroup/SelectButton/__tests__/__snapshots__/SelectButton.spec.js.snap
@@ -2,19 +2,18 @@
 
 exports[`SelectButton should render correctly 1`] = `
 <SelectButton
-  context="brand"
-  isEqualWidth={false}
-  isSelected={false}
+  context="good"
+  isEqualWidth={true}
+  isSelected={true}
   onChange={[MockFunction]}
-  size="normal"
+  size="large"
   value="button 1"
 >
   <div
-    className="SelectButton SelectButton--context_brand"
+    className="SelectButton SelectButton--context_good SelectButton--size_large SelectButton--isEqualWidth SelectButton--isSelected"
     onClick={[Function]}
     onKeyPress={[Function]}
     role="button"
-    size="normal"
     tabIndex={0}
   >
     Option 1

--- a/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/SelectButtonGroup.spec.js
+++ b/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/SelectButtonGroup.spec.js
@@ -156,6 +156,16 @@ describe('SelectButtonGroup', () => {
                 getButton(1).prop('value'),
                 getButton(2).prop('value'),
             ]);
+
+            getButton(1).simulate('click');
+            expect(onChangeMock).toHaveBeenLastCalledWith([
+                getButton(0).prop('value'),
+                getButton(2).prop('value'),
+            ]);
+
+            getButton(0).simulate('click');
+            getButton(2).simulate('click');
+            expect(onChangeMock).toHaveBeenLastCalledWith([]);
         });
     });
 

--- a/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/SelectButtonGroup.spec.js
+++ b/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/SelectButtonGroup.spec.js
@@ -10,7 +10,7 @@ describe('SelectButtonGroup', () => {
 
     beforeEach(() => {
         wrapper = mount(
-            <SelectButtonGroup defaultValue={['1']}>
+            <SelectButtonGroup defaultValue={['1']} onChange={onChangeMock}>
                 <SelectButton value="1" key="1">
                     Option 1
                 </SelectButton>
@@ -60,6 +60,17 @@ describe('SelectButtonGroup', () => {
             expect(getButton(0).prop('isSelected')).toBeTruthy();
             expect(getButton(1).prop('isSelected')).toBeFalsy();
             expect(getButton(2).prop('isSelected')).toBeFalsy();
+        });
+
+        it('should call onChange with correct parameters', () => {
+            getButton(1).simulate('click');
+            expect(onChangeMock).toHaveBeenLastCalledWith([getButton(1).prop('value')]);
+
+            getButton(0).simulate('click');
+            expect(onChangeMock).toHaveBeenLastCalledWith([getButton(0).prop('value')]);
+
+            getButton(0).simulate('click');
+            expect(onChangeMock).toHaveBeenLastCalledWith([]);
         });
     });
     describe('Multi select mode', () => {
@@ -131,13 +142,27 @@ describe('SelectButtonGroup', () => {
             expect(getButton(1).prop('isSelected')).toBeTruthy();
             expect(getButton(2).prop('isSelected')).toBeFalsy();
         });
+
+        it('should call onChange with correct parameters', () => {
+            getButton(1).simulate('click');
+            expect(onChangeMock).toHaveBeenLastCalledWith([
+                getButton(0).prop('value'),
+                getButton(1).prop('value'),
+            ]);
+
+            getButton(2).simulate('click');
+            expect(onChangeMock).toHaveBeenLastCalledWith([
+                getButton(0).prop('value'),
+                getButton(1).prop('value'),
+                getButton(2).prop('value'),
+            ]);
+        });
     });
 
     describe('Controlled behavior', () => {
         beforeEach(() => {
             wrapper.setProps({
                 value: ['1'],
-                onChange: onChangeMock,
                 defaultValue: undefined,
             });
         });

--- a/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/SelectButtonGroup.spec.js
+++ b/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/SelectButtonGroup.spec.js
@@ -10,14 +10,14 @@ describe('SelectButtonGroup', () => {
 
     beforeEach(() => {
         wrapper = mount(
-            <SelectButtonGroup onChange={onChangeMock}>
-                <SelectButton value="button 1" isInitiallySelected key="1">
+            <SelectButtonGroup defaultValue={['1']}>
+                <SelectButton value="1" key="1">
                     Option 1
                 </SelectButton>
-                <SelectButton value="button 2" key="2">
+                <SelectButton value="2" key="2">
                     Option 2
                 </SelectButton>
-                <SelectButton value="button 3" key="3">
+                <SelectButton value="3" key="3">
                     Option 3
                 </SelectButton>
             </SelectButtonGroup>
@@ -60,16 +60,6 @@ describe('SelectButtonGroup', () => {
             expect(getButton(0).prop('isSelected')).toBeTruthy();
             expect(getButton(1).prop('isSelected')).toBeFalsy();
             expect(getButton(2).prop('isSelected')).toBeFalsy();
-        });
-        it('should call onChange with correct parameters', () => {
-            getButton(1).simulate('click');
-            expect(onChangeMock).toHaveBeenLastCalledWith([getButton(1).prop('value')]);
-
-            getButton(0).simulate('click');
-            expect(onChangeMock).toHaveBeenLastCalledWith([getButton(0).prop('value')]);
-
-            getButton(0).simulate('click');
-            expect(onChangeMock).toHaveBeenLastCalledWith([]);
         });
     });
     describe('Multi select mode', () => {
@@ -141,29 +131,25 @@ describe('SelectButtonGroup', () => {
             expect(getButton(1).prop('isSelected')).toBeTruthy();
             expect(getButton(2).prop('isSelected')).toBeFalsy();
         });
+    });
+
+    describe('Controlled behavior', () => {
+        beforeEach(() => {
+            wrapper.setProps({
+                value: ['1'],
+                onChange: onChangeMock,
+                defaultValue: undefined,
+            });
+        });
+
+        it('should render correctly', () => {
+            expect(toJson(wrapper)).toMatchSnapshot();
+        });
+
         it('should call onChange with correct parameters', () => {
+            expect(getButton(0).prop('isSelected')).toBeTruthy();
             getButton(1).simulate('click');
-            expect(onChangeMock).toHaveBeenLastCalledWith([
-                getButton(0).prop('value'),
-                getButton(1).prop('value'),
-            ]);
-
-            getButton(2).simulate('click');
-            expect(onChangeMock).toHaveBeenLastCalledWith([
-                getButton(0).prop('value'),
-                getButton(1).prop('value'),
-                getButton(2).prop('value'),
-            ]);
-
-            getButton(1).simulate('click');
-            expect(onChangeMock).toHaveBeenLastCalledWith([
-                getButton(0).prop('value'),
-                getButton(2).prop('value'),
-            ]);
-
-            getButton(0).simulate('click');
-            getButton(2).simulate('click');
-            expect(onChangeMock).toHaveBeenLastCalledWith([]);
+            expect(onChangeMock).toHaveBeenLastCalledWith(getButton(1).prop('value'));
         });
     });
 });

--- a/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/__snapshots__/SelectButtonGroup.spec.js.snap
+++ b/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/__snapshots__/SelectButtonGroup.spec.js.snap
@@ -98,7 +98,7 @@ exports[`SelectButtonGroup should render correctly 1`] = `
   isEqualWidth={false}
   isMultiselect={false}
   isRequired={false}
-  onChange={null}
+  onChange={[MockFunction]}
   size="normal"
   value={null}
 >

--- a/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/__snapshots__/SelectButtonGroup.spec.js.snap
+++ b/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/__snapshots__/SelectButtonGroup.spec.js.snap
@@ -25,7 +25,7 @@ exports[`SelectButtonGroup Controlled behavior should render correctly 1`] = `
       isEqualWidth={false}
       isSelected={true}
       key="1"
-      onChange={[MockFunction]}
+      onChange={[Function]}
       size="normal"
       value="1"
     >
@@ -46,7 +46,7 @@ exports[`SelectButtonGroup Controlled behavior should render correctly 1`] = `
       isEqualWidth={false}
       isSelected={false}
       key="2"
-      onChange={[MockFunction]}
+      onChange={[Function]}
       size="normal"
       value="2"
     >
@@ -67,7 +67,7 @@ exports[`SelectButtonGroup Controlled behavior should render correctly 1`] = `
       isEqualWidth={false}
       isSelected={false}
       key="3"
-      onChange={[MockFunction]}
+      onChange={[Function]}
       size="normal"
       value="3"
     >

--- a/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/__snapshots__/SelectButtonGroup.spec.js.snap
+++ b/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/__snapshots__/SelectButtonGroup.spec.js.snap
@@ -1,47 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SelectButtonGroup should render correctly 1`] = `
+exports[`SelectButtonGroup Controlled behavior should render correctly 1`] = `
 <SelectButtonGroup
+  context={null}
+  defaultValue={null}
   isBlock={false}
   isEqualWidth={false}
   isMultiselect={false}
   isRequired={false}
-  onChange={
-    [MockFunction] {
-      "calls": Array [
-        Array [
-          Array [
-            "button 1",
-          ],
-        ],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": undefined,
-        },
-      ],
-    }
-  }
-  selectedContext="brand"
+  onChange={[MockFunction]}
   size="normal"
+  value={
+    Array [
+      "1",
+    ]
+  }
 >
   <div
     className="SelectButtonGroup"
   >
     <SelectButton
+      context="brand"
       isBlock={false}
       isEqualWidth={false}
-      isInitiallySelected={true}
       isSelected={true}
       key="1"
-      onChange={[Function]}
-      selectedContext="brand"
+      onChange={[MockFunction]}
       size="normal"
-      value="button 1"
+      value="1"
     >
       <div
-        className="SelectButton SelectButton--isSelected SelectButton--selectedContext_brand"
+        className="SelectButton SelectButton--context_brand SelectButton--isSelected"
         onClick={[Function]}
         onKeyPress={[Function]}
         role="button"
@@ -52,18 +41,17 @@ exports[`SelectButtonGroup should render correctly 1`] = `
       </div>
     </SelectButton>
     <SelectButton
+      context="brand"
       isBlock={false}
       isEqualWidth={false}
-      isInitiallySelected={false}
       isSelected={false}
       key="2"
-      onChange={[Function]}
-      selectedContext="brand"
+      onChange={[MockFunction]}
       size="normal"
-      value="button 2"
+      value="2"
     >
       <div
-        className="SelectButton SelectButton--selectedContext_brand"
+        className="SelectButton SelectButton--context_brand"
         onClick={[Function]}
         onKeyPress={[Function]}
         role="button"
@@ -74,18 +62,103 @@ exports[`SelectButtonGroup should render correctly 1`] = `
       </div>
     </SelectButton>
     <SelectButton
+      context="brand"
       isBlock={false}
       isEqualWidth={false}
-      isInitiallySelected={false}
+      isSelected={false}
+      key="3"
+      onChange={[MockFunction]}
+      size="normal"
+      value="3"
+    >
+      <div
+        className="SelectButton SelectButton--context_brand"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        size="normal"
+        tabIndex={0}
+      >
+        Option 3
+      </div>
+    </SelectButton>
+  </div>
+</SelectButtonGroup>
+`;
+
+exports[`SelectButtonGroup should render correctly 1`] = `
+<SelectButtonGroup
+  context={null}
+  defaultValue={
+    Array [
+      "1",
+    ]
+  }
+  isBlock={false}
+  isEqualWidth={false}
+  isMultiselect={false}
+  isRequired={false}
+  onChange={null}
+  size="normal"
+  value={null}
+>
+  <div
+    className="SelectButtonGroup"
+  >
+    <SelectButton
+      context="brand"
+      isBlock={false}
+      isEqualWidth={false}
+      isSelected={true}
+      key="1"
+      onChange={[Function]}
+      size="normal"
+      value="1"
+    >
+      <div
+        className="SelectButton SelectButton--context_brand SelectButton--isSelected"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        size="normal"
+        tabIndex={0}
+      >
+        Option 1
+      </div>
+    </SelectButton>
+    <SelectButton
+      context="brand"
+      isBlock={false}
+      isEqualWidth={false}
+      isSelected={false}
+      key="2"
+      onChange={[Function]}
+      size="normal"
+      value="2"
+    >
+      <div
+        className="SelectButton SelectButton--context_brand"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        size="normal"
+        tabIndex={0}
+      >
+        Option 2
+      </div>
+    </SelectButton>
+    <SelectButton
+      context="brand"
+      isBlock={false}
+      isEqualWidth={false}
       isSelected={false}
       key="3"
       onChange={[Function]}
-      selectedContext="brand"
       size="normal"
-      value="button 3"
+      value="3"
     >
       <div
-        className="SelectButton SelectButton--selectedContext_brand"
+        className="SelectButton SelectButton--context_brand"
         onClick={[Function]}
         onKeyPress={[Function]}
         role="button"

--- a/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/__snapshots__/SelectButtonGroup.spec.js.snap
+++ b/src/components/SelectButtonGroup/SelectButtonGroup/__tests__/__snapshots__/SelectButtonGroup.spec.js.snap
@@ -34,7 +34,6 @@ exports[`SelectButtonGroup Controlled behavior should render correctly 1`] = `
         onClick={[Function]}
         onKeyPress={[Function]}
         role="button"
-        size="normal"
         tabIndex={0}
       >
         Option 1
@@ -55,7 +54,6 @@ exports[`SelectButtonGroup Controlled behavior should render correctly 1`] = `
         onClick={[Function]}
         onKeyPress={[Function]}
         role="button"
-        size="normal"
         tabIndex={0}
       >
         Option 2
@@ -76,7 +74,6 @@ exports[`SelectButtonGroup Controlled behavior should render correctly 1`] = `
         onClick={[Function]}
         onKeyPress={[Function]}
         role="button"
-        size="normal"
         tabIndex={0}
       >
         Option 3
@@ -120,7 +117,6 @@ exports[`SelectButtonGroup should render correctly 1`] = `
         onClick={[Function]}
         onKeyPress={[Function]}
         role="button"
-        size="normal"
         tabIndex={0}
       >
         Option 1
@@ -141,7 +137,6 @@ exports[`SelectButtonGroup should render correctly 1`] = `
         onClick={[Function]}
         onKeyPress={[Function]}
         role="button"
-        size="normal"
         tabIndex={0}
       >
         Option 2
@@ -162,7 +157,6 @@ exports[`SelectButtonGroup should render correctly 1`] = `
         onClick={[Function]}
         onKeyPress={[Function]}
         role="button"
-        size="normal"
         tabIndex={0}
       >
         Option 3

--- a/stories/SelectButtonGroup.tsx
+++ b/stories/SelectButtonGroup.tsx
@@ -15,6 +15,9 @@ storiesOf('Atoms|SelectButtonGroup', module)
             context={select('Default selected color context', CONTEXTS, CONTEXTS[1])}
             size={select('Size', SIZES, SIZES[1])}
             defaultValue={['3']}
+            onChange={(selection) => {
+                console.log('Current selection', selection);
+            }}
         >
             <SelectButton value="1" key="button 1">
                 {text('Option label 1', 'Option 1')}
@@ -28,15 +31,24 @@ storiesOf('Atoms|SelectButtonGroup', module)
         </SelectButtonGroup>
     ))
     .add('Controlled', () => {
-        const buttons = [1, 2, 3];
-        const selectedButton = select('Selected button', buttons, buttons[0]);
+        const buttons = {
+            '1': boolean('Button 1 selected', true),
+            '2': boolean('Button 2 selected', false),
+            '3': boolean('Button 3 selected', false),
+        };
+        const keys = Object.keys(buttons);
 
         return (
-            <SelectButtonGroup value={[selectedButton]}>
-                {buttons.map((buttonNumber) => (
+            <SelectButtonGroup
+                value={keys.filter((k) => buttons[k])}
+                onChange={(value) => {
+                    console.log(`Button ${value} was selected`);
+                }}
+            >
+                {keys.map((buttonNumber) => (
                     <SelectButton
+                        key={`button-${buttonNumber}`}
                         value={buttonNumber}
-                        isSelected={selectedButton === buttonNumber}
                         context={select(
                             `Context for button ${buttonNumber}`,
                             CONTEXTS,

--- a/stories/SelectButtonGroup.tsx
+++ b/stories/SelectButtonGroup.tsx
@@ -6,46 +6,46 @@ import { CONTEXTS, SIZES } from '../src/constants';
 
 storiesOf('Atoms|SelectButtonGroup', module)
     .addDecorator(withKnobs)
-    .add('SelectButtonGroup', () => (
+    .add('Uncontrolled', () => (
         <SelectButtonGroup<string>
             isMultiselect={boolean('Multiselect group', false)}
             isRequired={boolean('Require to have at least 1 selected option', false)}
             isBlock={boolean('Display as block', false)}
             isEqualWidth={boolean('Make all buttons the same width', false)}
-            selectedContext={select('Default selected color context', CONTEXTS, CONTEXTS[1])}
+            context={select('Default selected color context', CONTEXTS, CONTEXTS[1])}
             size={select('Size', SIZES, SIZES[1])}
-            onChange={(value) => {
-                const msg = `onSelect was called with values ${value}`;
-                console.log(msg);
-            }}
+            defaultValue={['3']}
         >
-            <SelectButton<string>
-                value="button 1"
-                key="button 1"
-                isInitiallySelected
-                selectedContext={
-                    select('Selected color context for button 1', CONTEXTS, undefined) || undefined
-                }
-            >
+            <SelectButton value="1" key="button 1">
                 {text('Option label 1', 'Option 1')}
             </SelectButton>
-            <SelectButton<string>
-                key="button 2"
-                value="button 2"
-                selectedContext={
-                    select('Selected color context for button 2', CONTEXTS, undefined) || undefined
-                }
-            >
+            <SelectButton value="2" key="button 2">
                 {text('Option label 2', 'Option 2')}
             </SelectButton>
-            <SelectButton<string>
-                key="button 3"
-                value="button 3"
-                selectedContext={
-                    select('Selected color context for button 3', CONTEXTS, undefined) || undefined
-                }
-            >
+            <SelectButton value="3" key="button 3">
                 {text('Option label 3', 'Option 3')}
             </SelectButton>
         </SelectButtonGroup>
-    ));
+    ))
+    .add('Controlled', () => {
+        const buttons = [1, 2, 3];
+        const selectedButton = select('Selected button', buttons, buttons[0]);
+
+        return (
+            <SelectButtonGroup value={[selectedButton]}>
+                {buttons.map((buttonNumber) => (
+                    <SelectButton
+                        value={buttonNumber}
+                        isSelected={selectedButton === buttonNumber}
+                        context={select(
+                            `Context for button ${buttonNumber}`,
+                            CONTEXTS,
+                            CONTEXTS[1]
+                        )}
+                    >
+                        Button {buttonNumber}
+                    </SelectButton>
+                ))}
+            </SelectButtonGroup>
+        );
+    });


### PR DESCRIPTION
This adds support for using this component with controlled data while preserving the possibility to use it in an uncontrolled way. Following the API changes, (default) values are meant to be defined on `SelectButtonGroup`. Use `value` in a controlled implementation, or `defaultValue` when uncontrolled. Context (prop is renamed to `context`) can be defined both on `SelectButtonGroup` level (applies to all children) or on each `SelectButton` individually.

BREAKING CHANGE: The API for these components is changed because of the improvements and changes in behavior that are implemented.

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
