### PR TITLE
fix(Toggle): do not allow Toggle to shrink

### DIFF
--- a/src/components/Toggle/Toggle.scss
+++ b/src/components/Toggle/Toggle.scss
@@ -12,6 +12,7 @@
         position: relative;
         background-color: var(--color-neutral);
         transition: border-color 300ms;
+        flex-shrink: 0;
 
         .Toggle__realCheckbox {
             position: absolute;


### PR DESCRIPTION
Prevent Toggle from shrinking below its intended width when used inside a narrow container

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
