### PR TITLE
fix(Sliders): vertically align handles in the middle of the rail

### DIFF
--- a/src/components/Sliders/Slider.scss
+++ b/src/components/Sliders/Slider.scss
@@ -6,7 +6,7 @@ $slider-handle-size: 18px;
 $slider-handle-border-width: 2px;
 
 // Centering adjustments of the handle on the rail
-$slider-handle-adjust-top: -(math.div($slider-handle-size, 2) - math.div($slider-rail-height, 4));
+$slider-handle-margin-top: -(math.div($slider-handle-size, 2));
 
 // Definitions of variables for paddings, shadows, etc.
 $slider-padding: 5px 0;
@@ -23,13 +23,14 @@ $slider-padding: 5px 0;
     position: absolute;
     width: $slider-handle-size;
     height: $slider-handle-size;
-    margin-top: $slider-handle-adjust-top;
+    margin-top: $slider-handle-margin-top;
     border: solid $slider-handle-border-width var(--color-brand);
     border-radius: 50%;
     transition: background-color var(--transition-duration) ease,
         transform var(--transition-duration), box-shadow var(--transition-duration);
     background-color: var(--color-background);
     cursor: grab;
+    top: 50%;
 
     &:active {
         cursor: grabbing;


### PR DESCRIPTION
Adjust the alignment of slider handles so they are vertically positioned in the middle of the slider rail

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
