### PR TITLE
feat(Link): Add prop to disable text decoration on hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "main": "dist/oneui.min.js",
     "types": "dist/dts/src/index.d.ts",
     "scripts": {
+        "start": "npm run storybook",
         "storybook": "start-storybook -s ./stories/static -p 9001 -c .storybook",
         "storybook:build": "build-storybook -s ./stories/static -c .storybook -o .out",
         "storybook:deploy": "storybook-to-ghpages --script=storybook:build --out=.out",

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -8,6 +8,10 @@
         text-decoration: var(--link-decoration-hover);
     }
 
+    &--dontDecorateOnHover:hover {
+        text-decoration: var(--link-decoration-normal);
+    }
+
     &--context_muted {
         color: var(--color-muted);
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -9,12 +9,14 @@ interface Props extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     context?: 'brand' | 'muted';
     /** Ref to access the anchor */
     ref?: React.RefObject<HTMLAnchorElement>;
+    /** Do not underline text on hover */
+    dontDecorateOnHover?: boolean;
 }
 
 const { block } = bem('Link', styles);
 
 export const Link: React.FC<Props> = React.forwardRef((props, ref) => {
-    const { children, context, ...rest } = props;
+    const { children, context, dontDecorateOnHover, ...rest } = props;
     return (
         <a ref={ref} {...rest} {...block(props)}>
             {children}
@@ -26,4 +28,5 @@ Link.displayName = 'Link';
 
 Link.defaultProps = {
     context: 'brand',
+    dontDecorateOnHover: false,
 };

--- a/stories/Link.tsx
+++ b/stories/Link.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text, select, withKnobs } from '@storybook/addon-knobs';
+import { text, select, boolean, withKnobs } from '@storybook/addon-knobs';
 import { Link } from '@textkernel/oneui';
 
 storiesOf('Atoms|Link', module)
@@ -10,6 +10,7 @@ storiesOf('Atoms|Link', module)
             target="_blank"
             href="https://textkernel.com"
             context={select('Context', ['muted', 'brand'], 'brand')}
+            dontDecorateOnHover={boolean("Don't decorate on hover", false)}
         >
             {text('Link text', 'Click me')}
         </Link>


### PR DESCRIPTION
We encountered several places where we use Link in the navigation. We always had to implement extra logic, and html elements to get rid of the text highlighting on hover. It will be much cleaner when it is implemented here.

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
