### PR TITLE
chore: change declaration for peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,10 +113,10 @@
                 "npm": ">=7.1.0"
             },
             "peerDependencies": {
-                "react": "^16.8.6",
-                "react-dom": "^16.8.6",
-                "react-icons": "^3.7.0",
-                "react-transition-group": "^4.3.0"
+                "react": ">=16.8.6 || 17.x",
+                "react-dom": ">=16.8.6 || 17.x",
+                "react-icons": ">=3.7.0 || 4.x",
+                "react-transition-group": ">=4.3.0"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -73,10 +73,10 @@
         "tippy.js": "6.3.7"
     },
     "peerDependencies": {
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6",
-        "react-icons": "^3.7.0",
-        "react-transition-group": "^4.3.0"
+        "react": ">=16.8.6 || 17.x",
+        "react-dom": ">=16.8.6 || 17.x",
+        "react-icons": ">=3.7.0 || 4.x",
+        "react-transition-group": ">=4.3.0"
     },
     "devDependencies": {
         "@babel/cli": "7.17.6",


### PR DESCRIPTION
We cannot update OneUI because of outdated peer dependency. This PR update the dependency declaration to work with newer versions too.

```
ngui|develop ⇒ npm i
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: jobfeed-ngui@0.0.1
npm ERR! Found: react-icons@4.3.1
npm ERR! node_modules/react-icons
npm ERR!   react-icons@"^4.3.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react-icons@"^3.7.0" from @textkernel/oneui@17.2.0
npm ERR! node_modules/@textkernel/oneui
npm ERR!   @textkernel/oneui@"^17.1.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```