### PR TITLE
fix: added missed px unit in font-size-large

### DIFF
--- a/src/themes/oneui/base-variables/_typography.scss
+++ b/src/themes/oneui/base-variables/_typography.scss
@@ -3,7 +3,7 @@ $font-size-base: 14px !default;
 $font-size-x-small: 10px !default;
 $font-size-small: 12px !default;
 $font-size-normal: 14px !default;
-$font-size-large: 16.8 !default;
+$font-size-large: 16.8px !default;
 
 $line-height-x-small: 1.4 * $font-size-x-small !default;
 $line-height-small: 1.4 * $font-size-small !default;


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. Use imperative, present tense in your commit description ("change", not "changed" or "changes") without uppercases or period (.) at the end.

# Checklist
- [ ] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [ ] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [ ] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [ ] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [ ] Component PropTypes are sufficiently described / documented.
- [ ] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
