### PR TITLE
feat(Checkbox): add `asFlexbox` prop to allow for different layout styles

### DIFF
--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -16,6 +16,10 @@
         vertical-align: middle;
         margin-right: var(--spacing-2x);
 
+        &--asFlexbox {
+            flex-shrink: 0;
+        }
+
         &:before {
             content: '';
             width: 100%;
@@ -38,6 +42,11 @@
             .Checkbox__box {
                 border-color: var(--color-brand);
             }
+        }
+
+        &--asFlexbox {
+            display: flex;
+            align-items: center;
         }
     }
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -11,12 +11,14 @@ interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
     disabled?: boolean;
     /** The label for the checkbox */
     children?: string | React.ReactElement;
+    /** Optionally render checkbox in a flexbox */
+    asFlexbox?: boolean;
 }
 
 const { block, elem } = bem('Checkbox', styles);
 
 export const Checkbox: React.FC<Props> = forwardRef((props, ref) => {
-    const { id, children, disabled, ...rest } = props;
+    const { id, children, disabled, asFlexbox, className, style, ...rest } = props;
 
     let text = children;
     if (children && typeof children === 'string') {
@@ -28,7 +30,7 @@ export const Checkbox: React.FC<Props> = forwardRef((props, ref) => {
     }
 
     return (
-        <div {...block(props)}>
+        <div style={style} {...block(props)}>
             <input
                 {...rest}
                 {...elem('input', props)}
@@ -58,4 +60,5 @@ Checkbox.displayName = 'Checkbox';
 
 Checkbox.defaultProps = {
     disabled: false,
+    asFlexbox: false,
 };

--- a/src/components/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__tests__/__snapshots__/Checkbox.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`<Checkbox> that renders a checkbox should render checkbox with complex children 1`] = `
 <Checkbox
+  asFlexbox={false}
   disabled={false}
   id="c1"
 >
@@ -50,6 +51,7 @@ exports[`<Checkbox> that renders a checkbox should render checkbox with complex 
 
 exports[`<Checkbox> that renders a checkbox should render default checkbox correctly 1`] = `
 <Checkbox
+  asFlexbox={false}
   disabled={false}
   id="c1"
 >

--- a/src/components/LabelPicker/LabelPicker.scss
+++ b/src/components/LabelPicker/LabelPicker.scss
@@ -25,7 +25,7 @@ $labelingDialogWidth: 200px;
 
     &__label {
         display: inline-flex;
-        max-width: calc(#{$labelingDialogWidth} - 34px);
+        overflow: hidden;
     }
 
     &__labelText {

--- a/src/components/LabelPicker/LabelPicker.tsx
+++ b/src/components/LabelPicker/LabelPicker.tsx
@@ -94,6 +94,7 @@ export function LabelPicker<L extends Label>(props: Props<L>) {
                                     checked={label.isSelected}
                                     onChange={getChangeHandler(label)}
                                     {...elem('checkbox')}
+                                    asFlexbox
                                 >
                                     <Text inline {...elem('label')}>
                                         <Text inline {...elem('labelText')} title={label.name}>

--- a/src/components/LabelPicker/__tests__/__snapshots__/LabelPicker.spec.js.snap
+++ b/src/components/LabelPicker/__tests__/__snapshots__/LabelPicker.spec.js.snap
@@ -130,6 +130,7 @@ exports[`<LabelPicker> that renders a dropdown type component to apply/remove/ad
           className="LabelPicker__scrollBox"
         >
           <Checkbox
+            asFlexbox={true}
             checked={false}
             className="LabelPicker__checkbox"
             disabled={false}
@@ -149,11 +150,11 @@ exports[`<LabelPicker> that renders a dropdown type component to apply/remove/ad
                 type="checkbox"
               />
               <label
-                className="Checkbox__label"
+                className="Checkbox__label Checkbox__label--asFlexbox"
                 htmlFor="First label"
               >
                 <span
-                  className="Checkbox__box"
+                  className="Checkbox__box Checkbox__box--asFlexbox"
                 >
                   <svg
                     className="Checkbox__svg"
@@ -202,6 +203,7 @@ exports[`<LabelPicker> that renders a dropdown type component to apply/remove/ad
             </div>
           </Checkbox>
           <Checkbox
+            asFlexbox={true}
             checked={true}
             className="LabelPicker__checkbox"
             disabled={false}
@@ -221,11 +223,11 @@ exports[`<LabelPicker> that renders a dropdown type component to apply/remove/ad
                 type="checkbox"
               />
               <label
-                className="Checkbox__label"
+                className="Checkbox__label Checkbox__label--asFlexbox"
                 htmlFor="Second label"
               >
                 <span
-                  className="Checkbox__box"
+                  className="Checkbox__box Checkbox__box--asFlexbox"
                 >
                   <svg
                     className="Checkbox__svg"
@@ -288,6 +290,7 @@ exports[`<LabelPicker> that renders a dropdown type component to apply/remove/ad
             </div>
           </Checkbox>
           <Checkbox
+            asFlexbox={true}
             checked={false}
             className="LabelPicker__checkbox"
             disabled={false}
@@ -307,11 +310,11 @@ exports[`<LabelPicker> that renders a dropdown type component to apply/remove/ad
                 type="checkbox"
               />
               <label
-                className="Checkbox__label"
+                className="Checkbox__label Checkbox__label--asFlexbox"
                 htmlFor="Third label"
               >
                 <span
-                  className="Checkbox__box"
+                  className="Checkbox__box Checkbox__box--asFlexbox"
                 >
                   <svg
                     className="Checkbox__svg"
@@ -360,6 +363,7 @@ exports[`<LabelPicker> that renders a dropdown type component to apply/remove/ad
             </div>
           </Checkbox>
           <Checkbox
+            asFlexbox={true}
             checked={false}
             className="LabelPicker__checkbox"
             disabled={false}
@@ -379,11 +383,11 @@ exports[`<LabelPicker> that renders a dropdown type component to apply/remove/ad
                 type="checkbox"
               />
               <label
-                className="Checkbox__label"
+                className="Checkbox__label Checkbox__label--asFlexbox"
                 htmlFor="Fourth label"
               >
                 <span
-                  className="Checkbox__box"
+                  className="Checkbox__box Checkbox__box--asFlexbox"
                 >
                   <svg
                     className="Checkbox__svg"

--- a/src/components/ProductTour/__tests__/__snapshots__/ProductTour.spec.js.snap
+++ b/src/components/ProductTour/__tests__/__snapshots__/ProductTour.spec.js.snap
@@ -466,6 +466,7 @@ exports[`ProductTour general rendering of first slide should render correctly wi
                   className="ProductTour__checkbox"
                 >
                   <Checkbox
+                    asFlexbox={false}
                     checked={false}
                     disabled={false}
                     id="hide"

--- a/stories/Checkbox.tsx
+++ b/stories/Checkbox.tsx
@@ -5,31 +5,57 @@ import { Checkbox, Text } from '@textkernel/oneui';
 
 storiesOf('Molecules|Checkbox', module)
     .addDecorator(withKnobs)
-    .add('Checkbox', () => (
-        <Checkbox
-            disabled={boolean('Disabled', false)}
-            id={text('Id', 'checkbox-1')}
-            onChange={(e) => {
-                console.log('Checkbox state changed', e);
-            }}
-        >
-            {text('Checkbox label', 'Select me!')}
-        </Checkbox>
-    ))
-    .add('Checkbox with callback', () => (
+    .add('Checkbox as controlled component', () => {
+        const [checked, setChecked] = React.useState(false);
+
+        const handleChange = (e) => {
+            console.log('Checkbox state changed', e);
+            setChecked(e.target.checked);
+        };
+
+        return (
+            <Checkbox
+                disabled={boolean('Disabled', false)}
+                id={text('Id', 'checkbox-1')}
+                onChange={handleChange}
+                checked={checked}
+                asFlexbox={boolean('Render in flexbox', false)}
+            >
+                {text('Checkbox label', 'Select me!')}
+            </Checkbox>
+        );
+    })
+    .add('Checkbox as uncontrolled component', () => (
         <Checkbox
             disabled={boolean('Disabled', false)}
             id={text('Id', 'checkbox-1')}
             onChange={(e) => console.log('Checkbox state changed', e)}
+            asFlexbox={boolean('Render in flexbox', false)}
             defaultChecked
         >
             {text('Checkbox label', 'Select me!')}
+        </Checkbox>
+    ))
+    .add('Checkbox with long label', () => (
+        <Checkbox
+            disabled={boolean('Disabled', false)}
+            id={text('Id', 'checkbox-1')}
+            onChange={(e) => console.log('Checkbox state changed', e)}
+            asFlexbox={boolean('Render in flexbox', false)}
+            defaultChecked
+            style={{ width: '150px' }}
+        >
+            {text(
+                'Checkbox label',
+                'This is a longer label text. Change flexbox rendering to see how it changes'
+            )}
         </Checkbox>
     ))
     .add('Checkbox with not just string as label', () => (
         <Checkbox
             disabled={boolean('Disabled', false)}
             id={text('Id', 'checkbox-1')}
+            asFlexbox={boolean('Render in flexbox', false)}
             onChange={(e) => console.log('Checkbox state changed', e)}
         >
             <Text inline style={{ color: 'turquoise' }} className="test-class">

--- a/stories/LabelPicker.tsx
+++ b/stories/LabelPicker.tsx
@@ -15,7 +15,7 @@ const LABELS = [
         name: 'This is label 6 which has a very very long name and a count',
         isSelected: false,
         count: 654,
-        id: 5,
+        id: 6,
     },
 ];
 


### PR DESCRIPTION
When using checkboxes in LabelPicker in browsers that show scroll bars in the traditional way (not as overlays) the layout breaks and labels are displayed in a separate line from the checkbox itself. In order to fix this, we need the checkbox to be in a flexbox. However, this as default behaviour can negatively effect already existing implementations. Hence this option is added via a new prop. 

This new prop is now used in LabelPicker.

This PR also fixes a small bug with passing `style` and `className` to Checkbox that were applied to the wrong HTML element.

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [ ] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [ ] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [ ] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
