### PR TITLE
feat(Teaser): add prop for disabled styling

### DIFF
--- a/src/components/Teaser/Teaser.tsx
+++ b/src/components/Teaser/Teaser.tsx
@@ -20,15 +20,17 @@ interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
     details?: SingleReactNode;
     /** Statuses of entity containing status label and tooltip message */
     statuses?: Status[];
+    /** Style the component as disabled */
+    disabled?: boolean;
 }
 
 const { block, elem } = bem('Teaser', styles);
 
 export const Teaser: React.FC<Props> = (props) => {
-    const { title, subTitle, location, details, statuses, ...rest } = props;
+    const { title, subTitle, location, details, statuses, disabled, ...rest } = props;
 
     const subTitleElement = (
-        <Text inline context="accent" {...elem('subTitle', props)}>
+        <Text inline context={disabled ? 'muted' : 'accent'} {...elem('subTitle', props)}>
             {subTitle}
         </Text>
     );
@@ -40,7 +42,7 @@ export const Teaser: React.FC<Props> = (props) => {
     return (
         <div {...rest} {...block(props)}>
             <div {...elem('line', props)}>
-                <Text inline context="brand" {...elem('title', props)}>
+                <Text inline context={disabled ? 'muted' : 'brand'} {...elem('title', props)}>
                     {title}
                 </Text>
                 {location && (
@@ -84,4 +86,5 @@ Teaser.defaultProps = {
     location: '',
     subTitle: '',
     details: '',
+    disabled: false,
 };

--- a/src/components/Teaser/__tests__/Teaser.spec.js
+++ b/src/components/Teaser/__tests__/Teaser.spec.js
@@ -29,5 +29,22 @@ describe('Teaser', () => {
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
+        expect(wrapper.find('Text').at(0).prop('context')).toEqual('brand');
+        expect(wrapper.find('Text').at(2).prop('context')).toEqual('accent');
+    });
+    it('should render correctly in disabled mode', () => {
+        const wrapper = mount(
+            <Teaser
+                title="A job title"
+                location="location"
+                subTitle="Organization"
+                details="details about this job"
+                disabled
+            />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(wrapper.find('Text').at(0).prop('context')).toEqual('muted');
+        expect(wrapper.find('Text').at(2).prop('context')).toEqual('muted');
     });
 });

--- a/src/components/Teaser/__tests__/__snapshots__/Teaser.spec.js.snap
+++ b/src/components/Teaser/__tests__/__snapshots__/Teaser.spec.js.snap
@@ -1,8 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Teaser should render correctly in disabled mode 1`] = `
+<Teaser
+  details="details about this job"
+  disabled={true}
+  location="location"
+  subTitle="Organization"
+  title="A job title"
+>
+  <div
+    className="Teaser"
+  >
+    <div
+      className="Teaser__line"
+    >
+      <Text
+        className="Teaser__title"
+        context="muted"
+        inline={true}
+        size="normal"
+      >
+        <span
+          className="Text--context_muted Teaser__title"
+        >
+          A job title
+        </span>
+      </Text>
+      <Text
+        className="Teaser__location"
+        context="muted"
+        inline={true}
+        size="normal"
+      >
+        <span
+          className="Text--context_muted Teaser__location"
+        >
+          location
+        </span>
+      </Text>
+    </div>
+    <div
+      className="Teaser__line"
+    >
+      <Text
+        className="Teaser__subTitle"
+        context="muted"
+        inline={true}
+        size="normal"
+      >
+        <span
+          className="Text--context_muted Teaser__subTitle"
+        >
+          Organization
+        </span>
+      </Text>
+    </div>
+    <div
+      className="Teaser__line"
+    >
+      <Text
+        className="Teaser__details"
+        context="muted"
+        inline={true}
+        size="normal"
+      >
+        <span
+          className="Text--context_muted Teaser__details"
+        >
+          details about this job
+        </span>
+      </Text>
+    </div>
+  </div>
+</Teaser>
+`;
+
 exports[`Teaser should render correctly with just a title 1`] = `
 <Teaser
   details=""
+  disabled={false}
   location=""
   subTitle=""
   title="some title"
@@ -39,6 +115,7 @@ exports[`Teaser should render correctly with just a title 1`] = `
 exports[`Teaser should render with all props defined 1`] = `
 <Teaser
   details="details about this job"
+  disabled={false}
   location="location"
   statuses={
     Array [

--- a/stories/Teaser.tsx
+++ b/stories/Teaser.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { object, text, withKnobs } from '@storybook/addon-knobs';
+import { boolean, object, text, withKnobs } from '@storybook/addon-knobs';
 import { Teaser } from '@textkernel/oneui';
 
 storiesOf('Molecules|Teaser', module)
@@ -23,6 +23,7 @@ storiesOf('Molecules|Teaser', module)
                         tooltip: 'Imported two days ago',
                     }),
                 ]}
+                disabled={boolean('Disabled', false)}
             />
         );
     })
@@ -40,6 +41,7 @@ storiesOf('Molecules|Teaser', module)
                         tooltip: 'Viewed one day ago',
                     }),
                 ]}
+                disabled={boolean('Disabled', false)}
             />
         );
     })
@@ -51,6 +53,7 @@ storiesOf('Molecules|Teaser', module)
                 subTitle={text('SubTitle', 'Awsome inc.')}
                 location={text('Location', 'Melbourne')}
                 details={text('Details', 'It was posted here')}
+                disabled={boolean('Disabled', false)}
             />
         );
     });


### PR DESCRIPTION
Add a prop to disabled styling for Teaser, where all text is in muted color. 
See [JF-3008 ](https://textkernel.atlassian.net/browse/JF-3008)for details

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [ ] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [ ] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
