### PR TITLE
fix(Map): zoom map to reasonable view when using a single point marker

### DIFF
--- a/src/components/Map/Map/Map.tsx
+++ b/src/components/Map/Map/Map.tsx
@@ -13,6 +13,8 @@ const circleOptions = () => ({
     visible: true,
     zIndex: 1,
 });
+// the zoom level for a single point marker
+const ZOOM_FOR_ONE_POINT = 12;
 
 type CircularMarker = {
     center: {
@@ -124,6 +126,7 @@ const Map = React.forwardRef<GoogleMap, Props>((props, ref) => {
                 } else {
                     bounds.extend(firstMarker.center);
                     map.fitBounds(bounds);
+                    map.setZoom(ZOOM_FOR_ONE_POINT);
                 }
             } else if (circularMarkers.length) {
                 circularMarkers.forEach(({ center, radius }) => {


### PR DESCRIPTION
When adding a single point marker to the map, it automatically zoomed to max closeness. This view is hard to see, so now it zooms in a way that you can still see some context