### PR TITLE
feat(Tag): extend API with styling options and ForwardRef

### DIFF
--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -18,12 +18,27 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
     onDelete?: () => void;
     /** Callback, that is fired when a user clicks on an element */
     onClick?: () => void;
+    /** A css class to be applied to the content (child) */
+    contentClassName?: string;
+    /** A css style to be applied to the content (child) */
+    contentStyle?: React.CSSProperties;
 }
 
 const { block, elem } = bem('Tag', styles);
 
-export const Tag: React.FC<Props> = (props) => {
-    const { children, bgColor, maxWidth, size, onDelete, onClick, isSelected, ...rest } = props;
+export const Tag = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
+    const {
+        children,
+        bgColor,
+        maxWidth,
+        size,
+        onDelete,
+        onClick,
+        isSelected,
+        contentClassName,
+        contentStyle,
+        ...rest
+    } = props;
 
     // Generate title for children that are plain text (without tags)
     // If there is something different from the string (JSX) - children will be of object type.
@@ -55,6 +70,7 @@ export const Tag: React.FC<Props> = (props) => {
     return (
         <div
             {...rest}
+            ref={ref}
             {...block({ ...props, clickable: !!onClick })}
             {...(onClick && {
                 onClick,
@@ -67,13 +83,18 @@ export const Tag: React.FC<Props> = (props) => {
                 maxWidth,
             }}
         >
-            <Text size={size} {...(areChildrenString && { title: children })} {...elem('text')}>
+            <Text
+                size={size}
+                {...(areChildrenString && { title: children })}
+                {...elem('text', { elemClassName: contentClassName })}
+                style={contentStyle}
+            >
                 {children}
             </Text>
             {onDelete && (
                 <button
                     onClick={handleDeleteClick}
-                    onKeyPress={handleDeleteButtonKeyPress}
+                    onKeyDown={handleDeleteButtonKeyPress}
                     type="button"
                     {...elem('deleteButton')}
                 >
@@ -82,7 +103,7 @@ export const Tag: React.FC<Props> = (props) => {
             )}
         </div>
     );
-};
+});
 
 Tag.displayName = 'Tag';
 

--- a/src/components/Tag/__tests__/Tag.spec.js
+++ b/src/components/Tag/__tests__/Tag.spec.js
@@ -35,6 +35,8 @@ describe('<Tag> component', () => {
                 size={textSize}
                 onClick={onTagClick}
                 onDelete={onDeleteClick}
+                contentClassName="my-class"
+                contentStyle={{ color: 'red' }}
             >
                 {text}
             </Tag>
@@ -45,6 +47,7 @@ describe('<Tag> component', () => {
         expect(wrapper.find('.Tag').prop('style').maxWidth).toEqual(maxWidth);
         expect(wrapper.find('Text').prop('size')).toEqual(textSize);
         expect(wrapper.find('Tag .Tag__deleteButton MdClose').exists()).toBeTruthy();
+        expect(wrapper.find('.my-class')).toHaveLength(2);
 
         expect(toJson(wrapper)).toMatchSnapshot();
     });
@@ -85,7 +88,7 @@ describe('<Tag> component', () => {
         );
 
         wrapper.find(deleteButtonSelector).simulate('focus');
-        wrapper.find(deleteButtonSelector).simulate('keypress', { key: 'Enter' });
+        wrapper.find(deleteButtonSelector).simulate('keydown', { key: 'Enter' });
 
         expect(onTagClick).toHaveBeenCalledTimes(0);
         expect(onDeleteClick).toHaveBeenCalledTimes(1);

--- a/src/components/Tag/__tests__/__snapshots__/Tag.spec.js.snap
+++ b/src/components/Tag/__tests__/__snapshots__/Tag.spec.js.snap
@@ -3,6 +3,12 @@
 exports[`<Tag> component should render correctly with full list of props 1`] = `
 <Tag
   bgColor="#ccc"
+  contentClassName="my-class"
+  contentStyle={
+    Object {
+      "color": "red",
+    }
+  }
   isSelected={true}
   maxWidth="30px"
   onClick={[MockFunction]}
@@ -23,14 +29,24 @@ exports[`<Tag> component should render correctly with full list of props 1`] = `
     tabIndex={0}
   >
     <Text
-      className="Tag__text"
+      className="Tag__text my-class"
       context="default"
       inline={false}
       size="large"
+      style={
+        Object {
+          "color": "red",
+        }
+      }
       title="Tag text"
     >
       <p
-        className="Text--size_large Tag__text"
+        className="Text--size_large Tag__text my-class"
+        style={
+          Object {
+            "color": "red",
+          }
+        }
         title="Tag text"
       >
         Tag text
@@ -39,7 +55,7 @@ exports[`<Tag> component should render correctly with full list of props 1`] = `
     <button
       className="Tag__deleteButton"
       onClick={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       type="button"
     >
       <MdClose

--- a/stories/atoms/Tag.tsx
+++ b/stories/atoms/Tag.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { FiCheck } from 'react-icons/fi';
 import { Tag } from '@textkernel/oneui';
 
 export default {
@@ -31,4 +32,35 @@ _Tag.args = {
     maxWidth: 'fit-content',
     size: 'normal',
     children: 'This is an extremely long long text!',
+};
+
+export const TagWithIcon = (args) => {
+    return (
+        <div
+            style={{
+                padding: '5px',
+            }}
+        >
+            <Tag {...args} />
+        </div>
+    );
+};
+TagWithIcon.args = {
+    bgColor: '#3eff2b',
+    isSelected: false,
+    maxWidth: 'fit-content',
+    size: 'normal',
+    children: (
+        <>
+            <FiCheck />
+            Some text
+        </>
+    ),
+    contentClassName: 'test-class',
+    contentStyle: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--spacing-2x)',
+    },
+    onDelete: undefined,
 };


### PR DESCRIPTION
Story: [JF-3493](https://textkernel.atlassian.net/browse/JF-3493)

* Allow forward ref for Tag so it can be rendered in a Tooltip
* Add className and style props that will pass to the Text that wraps the child

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [ ] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [ ] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [ ] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [ ] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
