### PR TITLE
fix: buttongroup context isn't passed to the button

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -26,26 +26,20 @@ export const ButtonGroup = ({
 }: Props) => {
     const totalNumberOfButtons = React.Children.count(children);
 
-    if (totalNumberOfButtons === 1 && !Array.isArray(children)) {
-        return (
-            <div {...rest} {...block({ isBlock, ...rest })} role="group">
-                {React.isValidElement(children)
-                    ? React.cloneElement(children, {
-                          ...children.props,
-                          context,
-                          size,
-                          isBlock,
-                      })
-                    : children}
-            </div>
-        );
-    }
-
     return (
         <div {...rest} {...block({ isBlock, ...rest })} role="group">
             {React.Children.map(children, (button, i) => {
                 if (!React.isValidElement(button)) {
                     return button;
+                }
+
+                if (totalNumberOfButtons === 1) {
+                    return React.cloneElement(button, {
+                        ...button.props,
+                        context,
+                        size,
+                        isBlock,
+                    });
                 }
 
                 return React.cloneElement(button, {

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -26,7 +26,7 @@ export const ButtonGroup = ({
 }: Props) => {
     const totalNumberOfButtons = React.Children.count(children);
 
-    if (totalNumberOfButtons === 1) {
+    if (totalNumberOfButtons === 1 && !Array.isArray(children)) {
         return (
             <div {...rest} {...block({ isBlock, ...rest })} role="group">
                 {React.isValidElement(children)

--- a/src/components/ButtonGroup/__tests__/ButtonGroup.spec.tsx
+++ b/src/components/ButtonGroup/__tests__/ButtonGroup.spec.tsx
@@ -69,4 +69,19 @@ describe('<ButtonGroup> that renders a button', () => {
         expect(wrapper.find('Button').prop('size')).toBe('small');
         expect(wrapper.find('Button').prop('isBlock')).toBeTruthy();
     });
+
+    it('should pass main props if child is array with size one', () => {
+        const buttonContent = ['A button'];
+        const wrapper = mount(
+            <ButtonGroup context="warning" size="small" isBlock>
+                {buttonContent.map((content) => (
+                    <Button>{content}</Button>
+                ))}
+            </ButtonGroup>
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(wrapper.find('Button').prop('context')).toBe('warning');
+        expect(wrapper.find('Button').prop('size')).toBe('small');
+        expect(wrapper.find('Button').prop('isBlock')).toBeFalsy();
+    });
 });

--- a/src/components/ButtonGroup/__tests__/ButtonGroup.spec.tsx
+++ b/src/components/ButtonGroup/__tests__/ButtonGroup.spec.tsx
@@ -80,8 +80,9 @@ describe('<ButtonGroup> that renders a button', () => {
             </ButtonGroup>
         );
         expect(toJson(wrapper)).toMatchSnapshot();
+        expect(wrapper.find('Button').prop('className')).toBe(undefined);
         expect(wrapper.find('Button').prop('context')).toBe('warning');
         expect(wrapper.find('Button').prop('size')).toBe('small');
-        expect(wrapper.find('Button').prop('isBlock')).toBeFalsy();
+        expect(wrapper.find('Button').prop('isBlock')).toBeTruthy();
     });
 });

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -52,13 +52,13 @@ exports[`<ButtonGroup> that renders a button should pass main props if child is 
     role="group"
   >
     <Button
-      className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_warning ButtonGroup__button--first ButtonGroup__button--last"
       context="warning"
+      isBlock={true}
       key=".0"
       size="small"
     >
       <button
-        className="Button Button--context_warning Button--size_small ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_warning ButtonGroup__button--first ButtonGroup__button--last"
+        className="Button Button--context_warning Button--isBlock Button--size_small"
         disabled={false}
         type="button"
       >
@@ -82,6 +82,7 @@ exports[`<ButtonGroup> that renders a button should pass main props, but not add
     <Button
       context="warning"
       isBlock={true}
+      key=".0"
       size="small"
     >
       <button

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -41,6 +41,34 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
 </ButtonGroup>
 `;
 
+exports[`<ButtonGroup> that renders a button should pass main props if child is array with size one 1`] = `
+<ButtonGroup
+  context="warning"
+  isBlock={true}
+  size="small"
+>
+  <div
+    className="ButtonGroup ButtonGroup--isBlock"
+    role="group"
+  >
+    <Button
+      className="ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_warning ButtonGroup__button--first ButtonGroup__button--last"
+      context="warning"
+      key=".0"
+      size="small"
+    >
+      <button
+        className="Button Button--context_warning Button--size_small ButtonGroup__button ButtonGroup__button--isBlock ButtonGroup__button--context_warning ButtonGroup__button--first ButtonGroup__button--last"
+        disabled={false}
+        type="button"
+      >
+        A button
+      </button>
+    </Button>
+  </div>
+</ButtonGroup>
+`;
+
 exports[`<ButtonGroup> that renders a button should pass main props, but not add styles if there is only 1 child 1`] = `
 <ButtonGroup
   context="warning"


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. Use imperative, present tense in your commit description ("change", not "changed" or "changes") without uppercases or period (.) at the end.

# Checklist
- [ ] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [ ] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [ ] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [ ] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [ ] Component PropTypes are sufficiently described / documented.
- [ ] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
