### PR TITLE
fix(RadioButton): wrongly styled when disabled

### DIFF
--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -20,7 +20,7 @@ const { block, elem } = bem('RadioButton', styles);
 export const RadioButton = forwardRef<HTMLElement, Props>(
     ({ id, children, disabled = false, name, ...rest }, ref) => {
         return (
-            <div {...block({ ...rest })}>
+            <div {...block({ ...rest, disabled })}>
                 <input
                     {...rest}
                     {...elem('input')}

--- a/src/components/RadioButton/__tests__/RadioButton.spec.tsx
+++ b/src/components/RadioButton/__tests__/RadioButton.spec.tsx
@@ -31,6 +31,7 @@ describe('<RadioButton> that renders a radio button', () => {
                 Useless radio button
             </RadioButton>
         );
+        expect(toJson(wrapper)).toMatchSnapshot();
         expect(wrapper.find('input[disabled]')).toHaveLength(1);
         expect(wrapper.find('.Text--context_muted')).toHaveLength(1);
     });

--- a/src/components/RadioButton/__tests__/__snapshots__/RadioButton.spec.tsx.snap
+++ b/src/components/RadioButton/__tests__/__snapshots__/RadioButton.spec.tsx.snap
@@ -98,3 +98,60 @@ exports[`<RadioButton> that renders a radio button should render radio button wi
   </div>
 </RadioButton>
 `;
+
+exports[`<RadioButton> that renders a radio button should rendered disabled radio button correctly 1`] = `
+<RadioButton
+  disabled={true}
+  id="c3"
+>
+  <div
+    className="RadioButton--disabled"
+  >
+    <input
+      className="RadioButton__input"
+      disabled={true}
+      id="c3"
+      type="radio"
+    />
+    <label
+      className="RadioButton__label"
+      htmlFor="c3"
+    >
+      <span
+        className="RadioButton__box"
+      >
+        <svg
+          className="RadioButton__svg"
+          height="10px"
+          viewBox={
+            Array [
+              0,
+              0,
+              10,
+              10,
+            ]
+          }
+          width="12px"
+        >
+          <circle
+            cx="5"
+            cy="6"
+            r="3"
+          />
+        </svg>
+      </span>
+      <Text
+        className="RadioButton__text"
+        context="muted"
+        inline={true}
+      >
+        <span
+          className="Text--context_muted RadioButton__text"
+        >
+          Useless radio button
+        </span>
+      </Text>
+    </label>
+  </div>
+</RadioButton>
+`;


### PR DESCRIPTION
In one of the recent refactors a bug was introduced where styles for disabled RadioButton were not applied. This ticket reinstate those styles.