### PR TITLE
fix(TextArea): component types to be specific

### DIFF
--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -3,7 +3,7 @@ import { bem } from '../../utils';
 import styles from './TextArea.scss';
 import { Context, Size } from '../../constants';
 
-export interface Props extends React.HTMLAttributes<HTMLElement> {
+export interface Props extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
     /** The textarea context (e.g. brand, primary, bad, good etc. - defaults to brand) */
     context?: Context;
     /** Should the input field be disabled or not */
@@ -16,7 +16,7 @@ export interface Props extends React.HTMLAttributes<HTMLElement> {
 
 const { block } = bem('TextArea', styles);
 
-export const TextArea = forwardRef<HTMLElement, Props>(
+export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
     ({ context = 'brand', disabled = false, isBlock = false, size = 'normal', ...rest }, ref) => {
         return (
             <textarea


### PR DESCRIPTION
After migrating to TS, types were too generic and things like `maxLength` throw TS errors. This PR fixes that.

Note: for some reason errors were not visible in Storybook. Perhaps something we should look into later.