### PR TITLE
fix(scss): deprecation errors after color changes

### DIFF
--- a/src/themes/oneui/base-variables/_colors.scss
+++ b/src/themes/oneui/base-variables/_colors.scss
@@ -73,12 +73,12 @@ $color-muted-12: #75DFFB !default;
             --color-#{ $context }-#{ 50 - math.div($factor, 2) }: #{mix(
                 $color-background,
                 $value,
-                $factor
+                $factor * 1%
             )};
             --color-#{ $context }-#{ 50 + math.div($factor, 2) }: #{mix(
                 $color-foreground,
                 $value,
-                $factor
+                $factor * 1%
             )};
         }
     }


### PR DESCRIPTION
Fix for deprecation warning in tests:

```
DEPRECATION WARNING: $weight: Passing a number without unit % (50) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
73 │               --color-#{ $context }-#{ 50 - math.div($factor, 2) }: #{mix(
   │ ┌─────────────────────────────────────────────────────────────────────^
74 │ │                 $color-background,
75 │ │                 $value,
76 │ │                 $factor
77 │ │             )};
   │ └─────────────^
   ╵
    src/themes/oneui/base-variables/_colors.scss 73:69  @import
    src/themes/oneui/oneui.scss 1:9                     @import
    src/components/Dialogs/Dialog/Dialog.scss 1:9       root stylesheet
```