### PR TITLE
test: use `container` instead of `asFragment`

### DIFF
--- a/TESTING_LIBRARY_MIGRATION.md
+++ b/TESTING_LIBRARY_MIGRATION.md
@@ -24,8 +24,8 @@ expect(component).toMatchSnapshot();
 ```ts
 import { render } from '@testing-library/react';
 
-const { asFragment } = render(<MyComponent />);
-expect(asFragment()).toMatchSnapshot();
+const { container } = render(<MyComponent />);
+expect(container).toMatchSnapshot();
 ```
 
 #### Before ⭕:
@@ -40,8 +40,8 @@ expect(component).toMatchSnapshot();
 ```ts
 import { render } from '@testing-library/react';
 
-const { asFragment } = render(<MyComponent />);
-expect(asFragment()).toMatchSnapshot();
+const { container } = render(<MyComponent />);
+expect(container).toMatchSnapshot();
 ```
 
 #### Before ⭕:
@@ -56,8 +56,8 @@ expect(component).toMatchSnapshot();
 ```ts
 import { render } from '@testing-library/react';
 
-const { asFragment } = render(<MyComponent />);
-expect(asFragment()).toMatchSnapshot();
+const { container } = render(<MyComponent />);
+expect(container).toMatchSnapshot();
 ```
 
 ### Finding Elements
@@ -98,7 +98,7 @@ expect(wrapper.find('Button')).toHaveLength(1);
 ```ts
 import { render, screen } from 'react-test-renderer';
 
-const { asFragment } = render(<MyComponent />);
+const { container } = render(<MyComponent />);
 expect(screen.getByRole('button')).toBeInTheDocument();
 ```
 
@@ -118,10 +118,10 @@ expect(component).toMatchSnapshot();
 import { render, screen } from 'react-test-renderer';
 import userEvent from '@testing-library/user-event';
 
-const { asFragment } = render(<MyComponent />);
+const { container } = render(<MyComponent />);
 const user = userEvent.setup();
 await user.type(screen.getByDisplayValue(''), 'Utrecht');
-expect(asFragment()).toMatchSnapshot();
+expect(container).toMatchSnapshot();
 ```
 
 #### Before ⭕:
@@ -161,8 +161,8 @@ wrapper.setProps({ isArrowUp: true });
 ```ts
 import { render } from 'react-test-renderer';
 
-const { rerender, asFragment } = render(<MyComponent />);
-expect(asFragment()).toMatchSnapshot();
+const { rerender, container } = render(<MyComponent />);
+expect(container).toMatchSnapshot();
 rerender(<MyComponent isArrowUp> </MyComponent>);
 ```
 

--- a/src/components/ButtonGroup/__tests__/ButtonGroup.spec.tsx
+++ b/src/components/ButtonGroup/__tests__/ButtonGroup.spec.tsx
@@ -15,7 +15,7 @@ describe('<ButtonGroup> that renders a button', () => {
             </ButtonGroup>
         );
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         const button = screen.getAllByRole('button');
         expect(button[0]).toHaveClass('ButtonGroup__button--first');
         expect(button[0]).not.toHaveClass('ButtonGroup__button--last');
@@ -31,7 +31,7 @@ describe('<ButtonGroup> that renders a button', () => {
             </ButtonGroup>
         );
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         const button = screen.getAllByRole('button');
         expect(button[0]).toHaveClass('Button--size_large');
         expect(button[0]).toHaveClass('ButtonGroup__button--isBlock');
@@ -57,7 +57,7 @@ describe('<ButtonGroup> that renders a button', () => {
             </ButtonGroup>
         );
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
     });
 
     it('should render with conditional JSX', () => {
@@ -70,7 +70,7 @@ describe('<ButtonGroup> that renders a button', () => {
             </ButtonGroup>
         );
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         expect(screen.queryByText('false')).not.toBeInTheDocument();
     });
 
@@ -81,7 +81,7 @@ describe('<ButtonGroup> that renders a button', () => {
             </ButtonGroup>
         );
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         const button = screen.getByRole('button');
         expect(button).toHaveClass('Button--isPrimary');
         expect(button).toHaveClass('Button--size_small');
@@ -98,7 +98,7 @@ describe('<ButtonGroup> that renders a button', () => {
             </ButtonGroup>
         );
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         const button = screen.getByRole('button');
         expect(button).toHaveClass('Button--isPrimary');
         expect(button).toHaveClass('Button--size_small');

--- a/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/src/components/ButtonGroup/__tests__/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ButtonGroup> that renders a button should add classes when props are changed 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="ButtonGroup ButtonGroup--isBlock"
     role="group"
@@ -19,11 +19,11 @@ exports[`<ButtonGroup> that renders a button should add classes when props are c
       Another button
     </button>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<ButtonGroup> that renders a button should pass main props if child is array with size one 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="ButtonGroup ButtonGroup--isBlock"
     role="group"
@@ -35,11 +35,11 @@ exports[`<ButtonGroup> that renders a button should pass main props if child is 
       A button
     </button>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<ButtonGroup> that renders a button should pass main props, but not add styles if there is only 1 child 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="ButtonGroup ButtonGroup--isBlock"
     role="group"
@@ -51,11 +51,11 @@ exports[`<ButtonGroup> that renders a button should pass main props, but not add
       A button
     </button>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<ButtonGroup> that renders a button should render default button correctly 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="ButtonGroup"
     role="group"
@@ -73,11 +73,11 @@ exports[`<ButtonGroup> that renders a button should render default button correc
       Another button
     </button>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<ButtonGroup> that renders a button should render with conditional JSX 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="ButtonGroup"
     role="group"
@@ -89,11 +89,11 @@ exports[`<ButtonGroup> that renders a button should render with conditional JSX 
       A button
     </button>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<ButtonGroup> that renders a button should support mixed element types 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="ButtonGroup ButtonGroup--isBlock"
     role="group"
@@ -128,5 +128,5 @@ exports[`<ButtonGroup> that renders a button should support mixed element types 
       tabindex="-1"
     />
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Buttons/Button/__tests__/Button.spec.tsx
+++ b/src/components/Buttons/Button/__tests__/Button.spec.tsx
@@ -8,7 +8,7 @@ describe('<Button> that renders a button', () => {
     it('should render default button correctly', () => {
         const view = render(<Button>Click me</Button>);
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         expect(screen.queryByRole('button')).toBeInTheDocument();
     });
     it('should add classes when props are changed', () => {
@@ -18,7 +18,7 @@ describe('<Button> that renders a button', () => {
             </Button>
         );
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         const button = screen.getByRole('button');
         expect(button).toHaveClass('Button--isPrimary');
         expect(button).toHaveClass('Button--size_large');
@@ -54,7 +54,7 @@ describe('<Button> that renders a button', () => {
     it('should render an ancor element if href is defined', () => {
         const view = render(<Button href="/">Click me</Button>);
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         expect(screen.getByRole('link')).toBeInTheDocument();
     });
 });

--- a/src/components/Buttons/Button/__tests__/__snapshots__/Button.spec.tsx.snap
+++ b/src/components/Buttons/Button/__tests__/__snapshots__/Button.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Button> that renders a button should add classes when props are changed 1`] = `
-<DocumentFragment>
+<div>
   <button
     class="Button Button--isPrimary Button--isBlock Button--isLoading Button--size_large"
     type="button"
@@ -10,27 +10,27 @@ exports[`<Button> that renders a button should add classes when props are change
       Click me
     </span>
   </button>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<Button> that renders a button should render an ancor element if href is defined 1`] = `
-<DocumentFragment>
+<div>
   <a
     class="Button"
     href="/"
   >
     Click me
   </a>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<Button> that renders a button should render default button correctly 1`] = `
-<DocumentFragment>
+<div>
   <button
     class="Button"
     type="button"
   >
     Click me
   </button>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Buttons/FileButton/__tests__/FileButton.spec.tsx
+++ b/src/components/Buttons/FileButton/__tests__/FileButton.spec.tsx
@@ -8,7 +8,7 @@ describe('<FileButton> that renders a button', () => {
     it('should render default button correctly', () => {
         const view = render(<FileButton>Choose file</FileButton>);
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         expect(screen.getByLabelText('Choose file')).toBeInTheDocument();
     });
     it('should add classes when props are changed', () => {
@@ -18,7 +18,7 @@ describe('<FileButton> that renders a button', () => {
             </FileButton>
         );
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
     });
     it('should call click callback correctly', async () => {
         const onChangeMock = jest.fn();

--- a/src/components/Buttons/FileButton/__tests__/__snapshots__/FileButton.spec.tsx.snap
+++ b/src/components/Buttons/FileButton/__tests__/__snapshots__/FileButton.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<FileButton> that renders a button should add classes when props are changed 1`] = `
-<DocumentFragment>
+<div>
   <label
     class="Button Button--size_large Button--isBlock"
   >
@@ -11,11 +11,11 @@ exports[`<FileButton> that renders a button should add classes when props are ch
     />
     Click me
   </label>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<FileButton> that renders a button should render default button correctly 1`] = `
-<DocumentFragment>
+<div>
   <label
     class="Button"
   >
@@ -25,5 +25,5 @@ exports[`<FileButton> that renders a button should render default button correct
     />
     Choose file
   </label>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Buttons/SearchButton/__tests__/SearchButton.spec.tsx
+++ b/src/components/Buttons/SearchButton/__tests__/SearchButton.spec.tsx
@@ -8,7 +8,7 @@ describe('<SearchButton> that renders a search button', () => {
     it('should render default button correctly', () => {
         const view = render(<SearchButton />);
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         expect(screen.getByRole('button')).toBeInTheDocument();
     });
     it('should call click callback correctly', async () => {
@@ -24,7 +24,7 @@ describe('<SearchButton> that renders a search button', () => {
         const label = 'Search';
         const view = render(<SearchButton>{label}</SearchButton>);
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         expect(screen.getByText(label)).toBeInTheDocument();
     });
 });

--- a/src/components/Buttons/SearchButton/__tests__/__snapshots__/SearchButton.spec.tsx.snap
+++ b/src/components/Buttons/SearchButton/__tests__/__snapshots__/SearchButton.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<SearchButton> that renders a search button should render a button with a label correctly 1`] = `
-<DocumentFragment>
+<div>
   <button
     class="SearchButton SearchButton--withLabel"
     type="button"
@@ -22,11 +22,11 @@ exports[`<SearchButton> that renders a search button should render a button with
     </svg>
     Search
   </button>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<SearchButton> that renders a search button should render default button correctly 1`] = `
-<DocumentFragment>
+<div>
   <button
     class="SearchButton"
     type="button"
@@ -44,6 +44,7 @@ exports[`<SearchButton> that renders a search button should render default butto
         d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
       />
     </svg>
+    
   </button>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Buttons/StepperButton/__tests__/StepperButton.spec.tsx
+++ b/src/components/Buttons/StepperButton/__tests__/StepperButton.spec.tsx
@@ -9,7 +9,7 @@ describe('<StepperButton> component', () => {
     it('should render correctly', () => {
         view = render(<StepperButton icon="plus" />);
 
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         expect(screen.getByRole('button')).toBeInTheDocument();
     });
     it('should render all icons correctly', () => {

--- a/src/components/Buttons/StepperButton/__tests__/__snapshots__/StepperButton.spec.tsx.snap
+++ b/src/components/Buttons/StepperButton/__tests__/__snapshots__/StepperButton.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<StepperButton> component should render correctly 1`] = `
-<DocumentFragment>
+<div>
   <button
     class="StepperButton"
     type="button"
@@ -23,5 +23,5 @@ exports[`<StepperButton> component should render correctly 1`] = `
       />
     </svg>
   </button>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Chip/__tests__/Chip.spec.tsx
+++ b/src/components/Chip/__tests__/Chip.spec.tsx
@@ -4,7 +4,7 @@ import { Chip } from '../Chip';
 
 describe('<Chip> that renders a pill shaped chip', () => {
     it('should render correctly', () => {
-        const { asFragment } = render(<Chip>some text</Chip>);
-        expect(asFragment()).toMatchSnapshot();
+        const { container } = render(<Chip>some text</Chip>);
+        expect(container).toMatchSnapshot();
     });
 });

--- a/src/components/Chip/__tests__/__snapshots__/Chip.spec.tsx.snap
+++ b/src/components/Chip/__tests__/__snapshots__/Chip.spec.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Chip> that renders a pill shaped chip should render correctly 1`] = `
-<DocumentFragment>
+<div>
   <span
     class="Chip"
   >
     some text
   </span>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Dropdown/__tests__/Dropdown.spec.tsx
+++ b/src/components/Dropdown/__tests__/Dropdown.spec.tsx
@@ -38,18 +38,18 @@ describe('Dropdown', () => {
     });
 
     it('should render correctly closed', () => {
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         expect(screen.queryAllByRole('presentation')).toHaveLength(0);
     });
 
     it('should render correctly opened', async () => {
         await userEvent.click(screen.getByRole('button', { name: 'Click me!' }));
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         expect(screen.getAllByRole('listbox')).toHaveLength(1);
         expect(screen.getAllByRole('presentation')).toHaveLength(2);
     });
     it('should downshift only by enabled items with value', async () => {
-        const { asFragment } = render(
+        const { container } = render(
             <Dropdown
                 button={<Button isPrimary>Click me!</Button>}
                 onChange={mockOnChange}
@@ -71,7 +71,7 @@ describe('Dropdown', () => {
             </Dropdown>
         );
         await userEvent.click(screen.getAllByRole('button', { name: 'Click me!' })[1]);
-        expect(asFragment()).toMatchSnapshot();
+        expect(container).toMatchSnapshot();
         const keyDown = () => userEvent.click(screen.getAllByRole('listbox')[1]);
 
         // 1 keydown
@@ -112,7 +112,7 @@ describe('Dropdown', () => {
     });
 
     it('should render correctly with mixed children: array and single ListItem', async () => {
-        const { asFragment } = render(
+        const { container } = render(
             <Dropdown
                 button={<Button isPrimary>Click me!</Button>}
                 onChange={mockOnChange}
@@ -129,7 +129,7 @@ describe('Dropdown', () => {
             </Dropdown>
         );
         await userEvent.click(screen.getAllByRole('button', { name: 'Click me!' })[1]);
-        expect(asFragment()).toMatchSnapshot();
+        expect(container).toMatchSnapshot();
         expect(screen.getAllByRole('presentation')).toHaveLength(3);
     });
 
@@ -205,7 +205,7 @@ describe('Dropdown', () => {
 
     it('should allow for conditional rendering of items', async () => {
         const condition = false;
-        const { asFragment } = render(
+        const { container } = render(
             <Dropdown
                 button={<Button isPrimary>Click me!</Button>}
                 onChange={mockOnChange}
@@ -224,7 +224,7 @@ describe('Dropdown', () => {
         );
         await userEvent.click(screen.getAllByRole('button', { name: 'Click me!' })[1]);
 
-        expect(asFragment()).toMatchSnapshot();
+        expect(container).toMatchSnapshot();
         expect(screen.queryByText('false')).toBeNull();
     });
 });

--- a/src/components/Dropdown/__tests__/__snapshots__/Dropdown.spec.tsx.snap
+++ b/src/components/Dropdown/__tests__/__snapshots__/Dropdown.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Dropdown should allow for conditional rendering of items 1`] = `
-<DocumentFragment>
+<div>
   <button
     aria-expanded="true"
     aria-haspopup="listbox"
@@ -34,11 +34,11 @@ exports[`Dropdown should allow for conditional rendering of items 1`] = `
       </span>
     </li>
   </ul>
-</DocumentFragment>
+</div>
 `;
 
 exports[`Dropdown should downshift only by enabled items with value 1`] = `
-<DocumentFragment>
+<div>
   <button
     aria-expanded="true"
     aria-haspopup="listbox"
@@ -102,11 +102,11 @@ exports[`Dropdown should downshift only by enabled items with value 1`] = `
       </span>
     </li>
   </ul>
-</DocumentFragment>
+</div>
 `;
 
 exports[`Dropdown should render correctly closed 1`] = `
-<DocumentFragment>
+<div>
   <button
     aria-expanded="false"
     aria-haspopup="listbox"
@@ -124,11 +124,11 @@ exports[`Dropdown should render correctly closed 1`] = `
     role="listbox"
     tabindex="-1"
   />
-</DocumentFragment>
+</div>
 `;
 
 exports[`Dropdown should render correctly opened 1`] = `
-<DocumentFragment>
+<div>
   <button
     aria-expanded="true"
     aria-haspopup="listbox"
@@ -169,11 +169,11 @@ exports[`Dropdown should render correctly opened 1`] = `
       </span>
     </li>
   </ul>
-</DocumentFragment>
+</div>
 `;
 
 exports[`Dropdown should render correctly with mixed children: array and single ListItem 1`] = `
-<DocumentFragment>
+<div>
   <button
     aria-expanded="true"
     aria-haspopup="listbox"
@@ -224,5 +224,5 @@ exports[`Dropdown should render correctly with mixed children: array and single 
       </span>
     </li>
   </ul>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Field/__tests__/Field.spec.tsx
+++ b/src/components/Field/__tests__/Field.spec.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom';
 describe('<Field> that renders an input field', () => {
     it('should render a component with a label properly', () => {
         const labelText = 'labelText';
-        const wrapper = render(
+        const view = render(
             <Field labelText={labelText} className="customClass">
                 <input />
             </Field>
@@ -14,6 +14,6 @@ describe('<Field> that renders an input field', () => {
         const button = screen.getByRole('textbox', { name: labelText });
 
         expect(button).toBeInTheDocument();
-        expect(wrapper.container).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
     });
 });

--- a/src/components/Field/__tests__/Field.spec.tsx
+++ b/src/components/Field/__tests__/Field.spec.tsx
@@ -14,6 +14,6 @@ describe('<Field> that renders an input field', () => {
         const button = screen.getByRole('textbox', { name: labelText });
 
         expect(button).toBeInTheDocument();
-        expect(wrapper.asFragment()).toMatchSnapshot();
+        expect(wrapper.container).toMatchSnapshot();
     });
 });

--- a/src/components/Field/__tests__/__snapshots__/Field.spec.tsx.snap
+++ b/src/components/Field/__tests__/__snapshots__/Field.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Field> that renders an input field should render a component with a label properly 1`] = `
-<DocumentFragment>
+<div>
   <label
     class="customClass"
   >
@@ -12,5 +12,5 @@ exports[`<Field> that renders an input field should render a component with a la
     </p>
     <input />
   </label>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/FieldWithValidation/__tests__/FieldWithValidation.spec.tsx
+++ b/src/components/FieldWithValidation/__tests__/FieldWithValidation.spec.tsx
@@ -9,12 +9,12 @@ describe('FieldWithValidation', () => {
     describe('when rendering message as text', () => {
         describe('with no error message passed', () => {
             it('should simply render the child as it is', () => {
-                const { asFragment } = render(
+                const { container } = render(
                     <FieldWithValidation>
                         <Input />
                     </FieldWithValidation>
                 );
-                expect(asFragment()).toMatchSnapshot();
+                expect(container).toMatchSnapshot();
                 expect(screen.getByRole('textbox')).toBeInTheDocument();
             });
         });
@@ -23,12 +23,12 @@ describe('FieldWithValidation', () => {
     describe('with error message passed', () => {
         const message = 'invalid field';
         it('should set context to bad on child', () => {
-            const { asFragment } = render(
+            const { container } = render(
                 <FieldWithValidation errorMessage={message}>
                     <Input />
                 </FieldWithValidation>
             );
-            expect(asFragment()).toMatchSnapshot();
+            expect(container).toMatchSnapshot();
             const input = screen.getByRole('textbox');
             expect(input).toHaveAttribute('class', 'Input Input--context_danger');
             expect(input).toBeInTheDocument();
@@ -36,24 +36,24 @@ describe('FieldWithValidation', () => {
         });
 
         it('should render the message as text', () => {
-            const { asFragment } = render(
+            const { container } = render(
                 <FieldWithValidation errorMessage={message}>
                     <Input />
                 </FieldWithValidation>
             );
-            expect(asFragment()).toMatchSnapshot();
+            expect(container).toMatchSnapshot();
             expect(screen.getByText(message)).toBeInTheDocument();
         });
     });
     describe('when using tooltip', () => {
         describe('with no error message passed', () => {
             it('should not render a tooltip with no error message', () => {
-                const { asFragment } = render(
+                const { container } = render(
                     <FieldWithValidation useTooltip>
                         <Input />
                     </FieldWithValidation>
                 );
-                expect(asFragment()).toMatchSnapshot();
+                expect(container).toMatchSnapshot();
                 userEvent.click(screen.getByDisplayValue(''));
             });
         });
@@ -61,31 +61,31 @@ describe('FieldWithValidation', () => {
             const message = 'invalid field';
 
             it('should set context to bad on child', () => {
-                const { asFragment } = render(
+                const { container } = render(
                     <FieldWithValidation errorMessage={message}>
                         <Input />
                     </FieldWithValidation>
                 );
-                expect(asFragment()).toMatchSnapshot();
+                expect(container).toMatchSnapshot();
                 const input = screen.getByRole('textbox');
                 expect(input).toHaveAttribute('class', 'Input Input--context_danger');
             });
             it('should render the message when field is focused', () => {
-                const { asFragment } = render(
+                const { container } = render(
                     <FieldWithValidation errorMessage={message}>
                         <Input />
                     </FieldWithValidation>
                 );
-                expect(asFragment()).toMatchSnapshot();
+                expect(container).toMatchSnapshot();
                 expect(screen.queryByText(message)).toBeDefined();
             });
             it('should remove the message when field is blurred', () => {
-                const { asFragment } = render(
+                const { container } = render(
                     <FieldWithValidation errorMessage={message}>
                         <Input />
                     </FieldWithValidation>
                 );
-                expect(asFragment()).toMatchSnapshot();
+                expect(container).toMatchSnapshot();
                 expect(screen.queryByText(message)).toBeDefined();
             });
         });

--- a/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
+++ b/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FieldWithValidation when rendering message as text with no error message passed should simply render the child as it is 1`] = `
-<DocumentFragment>
+<div>
   <input
     class="Input"
     data-lpignore="true"
     type="text"
     value=""
   />
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWithValidation when using tooltip when error message is defined should remove the message when field is blurred 1`] = `
-<DocumentFragment>
+<div>
   <input
     class="Input Input--context_danger"
     data-lpignore="true"
@@ -24,11 +24,11 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
   >
     invalid field
   </p>
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWithValidation when using tooltip when error message is defined should render the message when field is focused 1`] = `
-<DocumentFragment>
+<div>
   <input
     class="Input Input--context_danger"
     data-lpignore="true"
@@ -40,11 +40,11 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
   >
     invalid field
   </p>
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWithValidation when using tooltip when error message is defined should set context to bad on child 1`] = `
-<DocumentFragment>
+<div>
   <input
     class="Input Input--context_danger"
     data-lpignore="true"
@@ -56,22 +56,22 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
   >
     invalid field
   </p>
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWithValidation when using tooltip with no error message passed should not render a tooltip with no error message 1`] = `
-<DocumentFragment>
+<div>
   <input
     class="Input"
     data-lpignore="true"
     type="text"
     value=""
   />
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWithValidation with error message passed should render the message as text 1`] = `
-<DocumentFragment>
+<div>
   <input
     class="Input Input--context_danger"
     data-lpignore="true"
@@ -83,11 +83,11 @@ exports[`FieldWithValidation with error message passed should render the message
   >
     invalid field
   </p>
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWithValidation with error message passed should set context to bad on child 1`] = `
-<DocumentFragment>
+<div>
   <input
     class="Input Input--context_danger"
     data-lpignore="true"
@@ -99,5 +99,5 @@ exports[`FieldWithValidation with error message passed should set context to bad
   >
     invalid field
   </p>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/FieldWrapper/__tests__/FieldWrapper.spec.tsx
+++ b/src/components/FieldWrapper/__tests__/FieldWrapper.spec.tsx
@@ -6,44 +6,44 @@ import '@testing-library/jest-dom';
 
 describe('FieldWrapper', () => {
     it('should render correctly', () => {
-        const { asFragment } = render(<FieldWrapper>some children</FieldWrapper>);
+        const { container } = render(<FieldWrapper>some children</FieldWrapper>);
 
-        expect(asFragment()).toMatchSnapshot();
+        expect(container).toMatchSnapshot();
     });
     it('should add clear button if showClearButton is true', () => {
-        const { asFragment } = render(
+        const { container } = render(
             <FieldWrapper showClearButton clearTooltipLabel="Clear">
                 some children
             </FieldWrapper>
         );
 
-        expect(asFragment()).toMatchSnapshot();
+        expect(container).toMatchSnapshot();
         const button = screen.getByRole('button', { name: 'Clear' });
         expect(button).toBeInTheDocument();
     });
     it('should render arrow icon pointing down', () => {
-        const { asFragment } = render(<FieldWrapper showArrow>some children</FieldWrapper>);
+        const { container } = render(<FieldWrapper showArrow>some children</FieldWrapper>);
 
-        expect(asFragment()).toMatchSnapshot();
+        expect(container).toMatchSnapshot();
     });
     it('should render arrow icon pointing up', () => {
-        const { asFragment } = render(
+        const { container } = render(
             <FieldWrapper showArrow isArrowUp>
                 some children
             </FieldWrapper>
         );
 
-        expect(asFragment()).toMatchSnapshot();
+        expect(container).toMatchSnapshot();
     });
     it('should call onArrowClick when arrow is clicked', async () => {
         const onArrowClickMock = jest.fn();
-        const { rerender, asFragment } = render(
+        const { rerender, container } = render(
             <FieldWrapper showArrow onArrowClick={onArrowClickMock}>
                 some children
             </FieldWrapper>
         );
 
-        expect(asFragment()).toMatchSnapshot();
+        expect(container).toMatchSnapshot();
         const svg = screen.getByRole('button');
         expect(svg).toBeInTheDocument();
         await userEvent.click(svg);
@@ -59,13 +59,13 @@ describe('FieldWrapper', () => {
     });
     it('should call onArrowClick when arrow is accessed by keyboard', async () => {
         const onArrowClickMock = jest.fn();
-        const { rerender, asFragment } = render(
+        const { rerender, container } = render(
             <FieldWrapper showArrow onArrowClick={onArrowClickMock}>
                 some children
             </FieldWrapper>
         );
 
-        expect(asFragment()).toMatchSnapshot();
+        expect(container).toMatchSnapshot();
         const svg = screen.getByRole('button');
         expect(svg).toBeInTheDocument();
         await userEvent.keyboard('S');
@@ -83,13 +83,13 @@ describe('FieldWrapper', () => {
     });
     it('should call onClear callback correctly', async () => {
         const onClearMock = jest.fn();
-        const { asFragment } = render(
+        const { container } = render(
             <FieldWrapper showClearButton clearTooltipLabel="Clear" onClear={onClearMock}>
                 tag
             </FieldWrapper>
         );
 
-        expect(asFragment()).toMatchSnapshot();
+        expect(container).toMatchSnapshot();
         const button = screen.getByRole('button', { name: 'Clear' });
         await userEvent.click(button);
         expect(onClearMock).toHaveBeenCalled();

--- a/src/components/FieldWrapper/__tests__/__snapshots__/FieldWrapper.spec.tsx.snap
+++ b/src/components/FieldWrapper/__tests__/__snapshots__/FieldWrapper.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FieldWrapper should add clear button if showClearButton is true 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="FieldWrapper"
   >
@@ -31,11 +31,11 @@ exports[`FieldWrapper should add clear button if showClearButton is true 1`] = `
       </svg>
     </button>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWrapper should call onArrowClick when arrow is accessed by keyboard 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="FieldWrapper"
   >
@@ -61,11 +61,11 @@ exports[`FieldWrapper should call onArrowClick when arrow is accessed by keyboar
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWrapper should call onArrowClick when arrow is clicked 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="FieldWrapper"
   >
@@ -91,11 +91,11 @@ exports[`FieldWrapper should call onArrowClick when arrow is clicked 1`] = `
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWrapper should call onClear callback correctly 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="FieldWrapper"
   >
@@ -125,11 +125,11 @@ exports[`FieldWrapper should call onClear callback correctly 1`] = `
       </svg>
     </button>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWrapper should render arrow icon pointing down 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="FieldWrapper"
   >
@@ -155,11 +155,11 @@ exports[`FieldWrapper should render arrow icon pointing down 1`] = `
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWrapper should render arrow icon pointing up 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="FieldWrapper"
   >
@@ -185,11 +185,11 @@ exports[`FieldWrapper should render arrow icon pointing up 1`] = `
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`FieldWrapper should render correctly 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="FieldWrapper"
   >
@@ -199,5 +199,5 @@ exports[`FieldWrapper should render correctly 1`] = `
       some children
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Icon/IconExtract/__tests__/IconExtract.spec.tsx
+++ b/src/components/Icon/IconExtract/__tests__/IconExtract.spec.tsx
@@ -5,6 +5,6 @@ import { IconExtract } from '../IconExtract';
 describe('<IconExtract>', () => {
     it('should render an Extract icon', () => {
         const view = render(<IconExtract />);
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
     });
 });

--- a/src/components/Icon/IconExtract/__tests__/__snapshots__/IconExtract.spec.tsx.snap
+++ b/src/components/Icon/IconExtract/__tests__/__snapshots__/IconExtract.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<IconExtract> should render an Extract icon 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -26,5 +26,5 @@ exports[`<IconExtract> should render an Extract icon 1`] = `
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Icon/IconHarvester/__tests__/IconHarvester.spec.tsx
+++ b/src/components/Icon/IconHarvester/__tests__/IconHarvester.spec.tsx
@@ -5,6 +5,6 @@ import { IconHarvester } from '../IconHarvester';
 describe('<IconHarvester>', () => {
     it('should render an Harvester icon', () => {
         const view = render(<IconHarvester />);
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
     });
 });

--- a/src/components/Icon/IconHarvester/__tests__/__snapshots__/IconHarvester.spec.tsx.snap
+++ b/src/components/Icon/IconHarvester/__tests__/__snapshots__/IconHarvester.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<IconHarvester> should render an Harvester icon 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -17,5 +17,5 @@ exports[`<IconHarvester> should render an Harvester icon 1`] = `
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Icon/IconJobfeed/__tests__/IconJobfeed.spec.tsx
+++ b/src/components/Icon/IconJobfeed/__tests__/IconJobfeed.spec.tsx
@@ -5,6 +5,6 @@ import { IconJobfeed } from '../IconJobfeed';
 describe('<IconJobfeed>', () => {
     it('should render an Jobfeed icon', () => {
         const view = render(<IconJobfeed />);
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
     });
 });

--- a/src/components/Icon/IconJobfeed/__tests__/__snapshots__/IconJobfeed.spec.tsx.snap
+++ b/src/components/Icon/IconJobfeed/__tests__/__snapshots__/IconJobfeed.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<IconJobfeed> should render an Jobfeed icon 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -17,5 +17,5 @@ exports[`<IconJobfeed> should render an Jobfeed icon 1`] = `
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Icon/IconMatch/__tests__/IconMatch.spec.tsx
+++ b/src/components/Icon/IconMatch/__tests__/IconMatch.spec.tsx
@@ -5,6 +5,6 @@ import { IconMatch } from '../IconMatch';
 describe('<IconMatch>', () => {
     it('should render an Match! icon', () => {
         const view = render(<IconMatch />);
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
     });
 });

--- a/src/components/Icon/IconMatch/__tests__/__snapshots__/IconMatch.spec.tsx.snap
+++ b/src/components/Icon/IconMatch/__tests__/__snapshots__/IconMatch.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<IconMatch> should render an Match! icon 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -20,5 +20,5 @@ exports[`<IconMatch> should render an Match! icon 1`] = `
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Icon/IconSearch/__tests__/IconSearch.spec.tsx
+++ b/src/components/Icon/IconSearch/__tests__/IconSearch.spec.tsx
@@ -5,6 +5,6 @@ import { IconSearch } from '../IconSearch';
 describe('<IconSearch>', () => {
     it('should render a Search! icon', () => {
         const view = render(<IconSearch />);
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
     });
 });

--- a/src/components/Icon/IconSearch/__tests__/__snapshots__/IconSearch.spec.tsx.snap
+++ b/src/components/Icon/IconSearch/__tests__/__snapshots__/IconSearch.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<IconSearch> should render a Search! icon 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -20,5 +20,5 @@ exports[`<IconSearch> should render a Search! icon 1`] = `
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Icon/IconSourcebox/__tests__/IconSourcebox.spec.tsx
+++ b/src/components/Icon/IconSourcebox/__tests__/IconSourcebox.spec.tsx
@@ -5,6 +5,6 @@ import { IconSourcebox } from '../IconSourcebox';
 describe('<IconSourcebox>', () => {
     it('should render an Sourcebox icon', () => {
         const view = render(<IconSourcebox />);
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
     });
 });

--- a/src/components/Icon/IconSourcebox/__tests__/__snapshots__/IconSourcebox.spec.tsx.snap
+++ b/src/components/Icon/IconSourcebox/__tests__/__snapshots__/IconSourcebox.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<IconSourcebox> should render an Sourcebox icon 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -23,5 +23,5 @@ exports[`<IconSourcebox> should render an Sourcebox icon 1`] = `
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Icon/IconTextkernel/__tests__/IconTextkernel.spec.tsx
+++ b/src/components/Icon/IconTextkernel/__tests__/IconTextkernel.spec.tsx
@@ -5,6 +5,6 @@ import { IconTextkernel } from '../IconTextkernel';
 describe('<IconTextkernel>', () => {
     it('should render an Textkernel icon', () => {
         const view = render(<IconTextkernel />);
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
     });
 });

--- a/src/components/Icon/IconTextkernel/__tests__/__snapshots__/IconTextkernel.spec.tsx.snap
+++ b/src/components/Icon/IconTextkernel/__tests__/__snapshots__/IconTextkernel.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<IconTextkernel> should render an Textkernel icon 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -17,5 +17,5 @@ exports[`<IconTextkernel> should render an Textkernel icon 1`] = `
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Icon/LogoTextkernel/__tests__/IconTextkernelFull.spec.tsx
+++ b/src/components/Icon/LogoTextkernel/__tests__/IconTextkernelFull.spec.tsx
@@ -5,6 +5,6 @@ import { LogoTextkernel } from '../LogoTextkernel';
 describe('<LogoTextkernel>', () => {
     it('should render an Textkernel icon', () => {
         const view = render(<LogoTextkernel />);
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
     });
 });

--- a/src/components/Icon/LogoTextkernel/__tests__/__snapshots__/IconTextkernelFull.spec.tsx.snap
+++ b/src/components/Icon/LogoTextkernel/__tests__/__snapshots__/IconTextkernelFull.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<LogoTextkernel> should render an Textkernel icon 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -44,5 +44,5 @@ exports[`<LogoTextkernel> should render an Textkernel icon 1`] = `
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/Icon/__tests__/IconBase.spec.tsx
+++ b/src/components/Icon/__tests__/IconBase.spec.tsx
@@ -10,7 +10,7 @@ describe('<IconBase> that renders an SVG wrapper with all options included', () 
                 <circle cx="50" cy="50" r="50" />
             </IconBase>
         );
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
 
         expect(screen.getByTitle('Icon base')).toBeInTheDocument();
     });
@@ -20,7 +20,7 @@ describe('<IconBase> that renders an SVG wrapper with all options included', () 
                 <circle cx="50" cy="50" r="50" />
             </IconBase>
         );
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         const img = screen.getByRole('img');
 
         expect(img).toBeInTheDocument();
@@ -34,7 +34,7 @@ describe('<IconBase> that renders an SVG wrapper with all options included', () 
                 <circle cx="50" cy="50" r="50" />
             </IconBase>
         );
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         const img = screen.getByRole('img');
 
         expect(img).toBeInTheDocument();
@@ -48,7 +48,7 @@ describe('<IconBase> that renders an SVG wrapper with all options included', () 
                 <circle cx="50" cy="50" r="50" />
             </IconBase>
         );
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         const img = screen.getByRole('img');
 
         expect(img).toBeInTheDocument();
@@ -62,7 +62,7 @@ describe('<IconBase> that renders an SVG wrapper with all options included', () 
                 <circle cx="50" cy="50" r="50" />
             </IconBase>
         );
-        expect(view.asFragment()).toMatchSnapshot();
+        expect(view.container).toMatchSnapshot();
         const img = screen.getByRole('img');
 
         expect(img).toBeInTheDocument();

--- a/src/components/Icon/__tests__/__snapshots__/IconBase.spec.tsx.snap
+++ b/src/components/Icon/__tests__/__snapshots__/IconBase.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<IconBase> that renders an SVG wrapper with all options included should apply height only to styles if size is provided with preserveAspectRatio 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -19,11 +19,11 @@ exports[`<IconBase> that renders an SVG wrapper with all options included should
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<IconBase> that renders an SVG wrapper with all options included should apply proportional styles if size is provided 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -41,11 +41,11 @@ exports[`<IconBase> that renders an SVG wrapper with all options included should
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<IconBase> that renders an SVG wrapper with all options included should correct negative sizes 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -63,11 +63,11 @@ exports[`<IconBase> that renders an SVG wrapper with all options included should
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<IconBase> that renders an SVG wrapper with all options included should not apply proportional styles if no size provided 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase"
   >
@@ -85,11 +85,11 @@ exports[`<IconBase> that renders an SVG wrapper with all options included should
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`<IconBase> that renders an SVG wrapper with all options included should render a default icon 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="IconBase IconBase--margin_right IconBase--isPrimary"
   >
@@ -111,5 +111,5 @@ exports[`<IconBase> that renders an SVG wrapper with all options included should
       />
     </svg>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/SelectComponents/Autosuggest/__tests__/Autosuggest.spec.tsx
+++ b/src/components/SelectComponents/Autosuggest/__tests__/Autosuggest.spec.tsx
@@ -47,7 +47,7 @@ describe('Autosuggest', () => {
 
     describe('rendering', () => {
         it('should initially render empty component correctly', () => {
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
         });
         it('should add additional attributes to input field when component is blurred', () => {
             const newProps = {
@@ -63,7 +63,7 @@ describe('Autosuggest', () => {
         it('should initially render focused component correctly', async () => {
             await setFocus();
 
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
             // TODO: will be fixed in ONEUI-364
             expect(screen.queryAllByRole('presentation')).toHaveLength(0);
         });
@@ -88,7 +88,7 @@ describe('Autosuggest', () => {
             rerenderView(newProps);
             await setFocus();
 
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
             // TODO: will be fixed in ONEUI-364
             expect(screen.getAllByRole('presentation')).toHaveLength(8);
         });
@@ -102,7 +102,7 @@ describe('Autosuggest', () => {
             await setFocus();
             await userEvent.type(inputNodeField, 'driver');
 
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
         });
         it('should render isLoading state', async () => {
             suggestionsList = SUGGESTIONS.slice(1, 20);
@@ -116,7 +116,7 @@ describe('Autosuggest', () => {
             // TODO: will be fixed in ONEUI-364
             expect(screen.getAllByRole('presentation')).toHaveLength(5);
             // TODO: check the specific things
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
         });
         it('should render mix suggestions and loader if allowMixingSuggestionsAndLoading is set to true', async () => {
             suggestionsList = SUGGESTIONS.slice(1, 3);

--- a/src/components/SelectComponents/Autosuggest/__tests__/__snapshots__/Autosuggest.spec.tsx.snap
+++ b/src/components/SelectComponents/Autosuggest/__tests__/__snapshots__/Autosuggest.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Autosuggest rendering should initially render empty component correctly 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -41,11 +41,11 @@ exports[`Autosuggest rendering should initially render empty component correctly
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`Autosuggest rendering should initially render focused component correctly 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -87,11 +87,11 @@ exports[`Autosuggest rendering should initially render focused component correct
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`Autosuggest rendering should initially render focused component with suggestions list correctly 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -214,11 +214,11 @@ exports[`Autosuggest rendering should initially render focused component with su
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`Autosuggest rendering should render component with suggestions 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -353,11 +353,11 @@ exports[`Autosuggest rendering should render component with suggestions 1`] = `
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`Autosuggest rendering should render isLoading state 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -501,5 +501,5 @@ exports[`Autosuggest rendering should render isLoading state 1`] = `
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/SelectComponents/Combobox/__tests__/Combobox.spec.tsx
+++ b/src/components/SelectComponents/Combobox/__tests__/Combobox.spec.tsx
@@ -45,7 +45,7 @@ describe('Combobox', () => {
 
     describe('rendering', () => {
         it('should initially render empty component correctly', () => {
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
         });
         it('should set focus on the input field', async () => {
             await setFocus();
@@ -68,7 +68,7 @@ describe('Combobox', () => {
             rerenderView(newProps);
             await setFocus();
 
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
             // TODO: will be fixed in ONEUI-364
             expect(screen.getAllByRole('presentation')).toHaveLength(1);
             expect(screen.getByText(noSuggestionsPlaceholder)).toBeInTheDocument();
@@ -92,7 +92,7 @@ describe('Combobox', () => {
                 rerenderView(newProps);
                 await setFocus();
 
-                expect(view.asFragment()).toMatchSnapshot();
+                expect(view.container).toMatchSnapshot();
                 expect(screen.getByText(SUGGESTIONS[1].name)).toBeInTheDocument();
             });
         });
@@ -179,7 +179,7 @@ describe('Combobox', () => {
     describe('callbacks', () => {
         describe('onSelectionAdd', () => {
             it('should be called on clicking on a suggestion', async () => {
-                expect(view.asFragment()).toMatchSnapshot();
+                expect(view.container).toMatchSnapshot();
                 await setFocus();
                 expect(mockOnSelectionAdd).not.toHaveBeenCalled();
 

--- a/src/components/SelectComponents/Combobox/__tests__/__snapshots__/Combobox.spec.tsx.snap
+++ b/src/components/SelectComponents/Combobox/__tests__/__snapshots__/Combobox.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Combobox callbacks onSelectionAdd should be called on clicking on a suggestion 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -62,11 +62,11 @@ exports[`Combobox callbacks onSelectionAdd should be called on clicking on a sug
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`Combobox rendering should initially render empty component correctly 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -127,11 +127,11 @@ exports[`Combobox rendering should initially render empty component correctly 1`
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`Combobox rendering should render noSuggestions placeholder when empty suggestions list is passed 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -203,11 +203,11 @@ exports[`Combobox rendering should render noSuggestions placeholder when empty s
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`Combobox rendering when blurred should show the selected value if available 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -266,5 +266,5 @@ exports[`Combobox rendering when blurred should show the selected value if avail
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/SelectComponents/ComboboxMulti/__tests__/ComboboxMulti.spec.tsx
+++ b/src/components/SelectComponents/ComboboxMulti/__tests__/ComboboxMulti.spec.tsx
@@ -43,14 +43,14 @@ describe('ComboboxMulti', () => {
 
     describe('rendering', () => {
         it('should initially render empty component correctly', () => {
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
         });
         it('should add additional attributes to input field when component is blurred', () => {
             const newProps = {
                 inputAttrs: { 'data-test': true, title: 'some title' },
             };
             rerenderView(newProps);
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
             const inputField = screen.getAllByRole('textbox')[0];
 
             expect(inputField.outerHTML).toMatch('data-test="true"');
@@ -88,7 +88,7 @@ describe('ComboboxMulti', () => {
             rerenderView(newProps);
             await setFocus();
 
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
             expect(screen.getAllByRole('presentation')).toHaveLength(1);
             expect(screen.getByText(noSuggestionsPlaceholder)).toBeInTheDocument();
         });

--- a/src/components/SelectComponents/ComboboxMulti/__tests__/__snapshots__/ComboboxMulti.spec.tsx.snap
+++ b/src/components/SelectComponents/ComboboxMulti/__tests__/__snapshots__/ComboboxMulti.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ComboboxMulti rendering should add additional attributes to input field when component is blurred 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -64,11 +64,11 @@ exports[`ComboboxMulti rendering should add additional attributes to input field
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`ComboboxMulti rendering should initially render empty component correctly 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -129,11 +129,11 @@ exports[`ComboboxMulti rendering should initially render empty component correct
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`ComboboxMulti rendering should render noSuggestions placeholder when empty suggestions list is passed 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -208,5 +208,5 @@ exports[`ComboboxMulti rendering should render noSuggestions placeholder when em
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;

--- a/src/components/SelectComponents/SelectBase/__tests__/SelectBase.spec.tsx
+++ b/src/components/SelectComponents/SelectBase/__tests__/SelectBase.spec.tsx
@@ -50,7 +50,7 @@ describe('SelectBase', () => {
 
     describe('rendering', () => {
         it('should initially render empty component correctly', () => {
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
         });
     });
     describe('with toggle arrow', () => {
@@ -60,7 +60,7 @@ describe('SelectBase', () => {
                 showArrow: true,
             };
             rerenderView(newProps);
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
 
             expect(screen.getByRole('button')).toBeInTheDocument();
         });
@@ -70,7 +70,7 @@ describe('SelectBase', () => {
                 showArrow: true,
             };
             rerenderView(newProps);
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
             const svg = screen.getByRole('button');
 
             expect(svg).toBeInTheDocument();
@@ -156,7 +156,7 @@ describe('SelectBase', () => {
     });
     describe('highlighting', () => {
         it('should highlight first item', () => {
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
             expect(screen.queryAllByRole('listbox')[0]).toBeInTheDocument();
         });
     });
@@ -182,7 +182,7 @@ describe('SelectBase', () => {
                 showClearButton: true,
             };
             rerenderView(newProps);
-            expect(view.asFragment()).toMatchSnapshot();
+            expect(view.container).toMatchSnapshot();
             const clearButton = screen.getByRole('button', { name: 'Clear' });
             await userEvent.click(clearButton);
 

--- a/src/components/SelectComponents/SelectBase/__tests__/__snapshots__/SelectBase.spec.tsx.snap
+++ b/src/components/SelectComponents/SelectBase/__tests__/__snapshots__/SelectBase.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SelectBase callbacks should call onClearAllSelected on Clear button click 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -71,11 +71,11 @@ exports[`SelectBase callbacks should call onClearAllSelected on Clear button cli
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`SelectBase highlighting should highlight first item 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -109,11 +109,11 @@ exports[`SelectBase highlighting should highlight first item 1`] = `
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`SelectBase rendering should initially render empty component correctly 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -147,11 +147,11 @@ exports[`SelectBase rendering should initially render empty component correctly 
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`SelectBase with toggle arrow should show arrows when showArrow is true 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -201,11 +201,11 @@ exports[`SelectBase with toggle arrow should show arrows when showArrow is true 
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`SelectBase with toggle arrow should toggle focus and the arrow when it is clicked 1`] = `
-<DocumentFragment>
+<div>
   <div
     class="SelectBase"
   >
@@ -255,5 +255,5 @@ exports[`SelectBase with toggle arrow should toggle focus and the arrow when it 
       </div>
     </div>
   </div>
-</DocumentFragment>
+</div>
 `;


### PR DESCRIPTION
Story: [ONEUI-380](https://textkernel.atlassian.net/browse/ONEUI-380)
