### PR TITLE
feat(Input): migrate to new design

### DIFF
--- a/src/components/FieldWithValidation/__tests__/FieldWithValidation.spec.tsx
+++ b/src/components/FieldWithValidation/__tests__/FieldWithValidation.spec.tsx
@@ -30,7 +30,10 @@ describe('FieldWithValidation', () => {
             );
             expect(container).toMatchSnapshot();
             const input = screen.getByRole('textbox');
-            expect(input).toHaveAttribute('class', 'Input Input--context_critical');
+            expect(input).toHaveAttribute(
+                'class',
+                'Input Input--context_critical Input--size_medium'
+            );
             expect(input).toBeInTheDocument();
             expect(screen.getByText(message)).toBeInTheDocument();
         });
@@ -75,7 +78,10 @@ describe('FieldWithValidation', () => {
 
                 const input = screen.getByRole('textbox');
 
-                expect(input).toHaveAttribute('class', 'Input Input--context_critical');
+                expect(input).toHaveAttribute(
+                    'class',
+                    'Input Input--context_critical Input--size_medium'
+                );
             });
 
             it('should render the message when field is focused', () => {

--- a/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
+++ b/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
@@ -23,12 +23,24 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
     for="input-field"
   />
   <input
+    aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
     id="input-field"
     type="text"
     value=""
   />
+  <div
+    class="Input__errorMessageWrapper"
+  >
+    <test-file-stub
+      classname="Input__icon"
+      viewbox="0 0 24 24"
+    />
+    <p
+      class="Input__errorMessage"
+    />
+  </div>
   <p
     class="Text--context_critical Text--size_small FieldWithValidation"
   >
@@ -44,12 +56,24 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
     for="input-field"
   />
   <input
+    aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
     id="input-field"
     type="text"
     value=""
   />
+  <div
+    class="Input__errorMessageWrapper"
+  >
+    <test-file-stub
+      classname="Input__icon"
+      viewbox="0 0 24 24"
+    />
+    <p
+      class="Input__errorMessage"
+    />
+  </div>
   <p
     class="Text--context_critical Text--size_small FieldWithValidation"
   >
@@ -65,12 +89,24 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
     for="input-field"
   />
   <input
+    aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
     id="input-field"
     type="text"
     value=""
   />
+  <div
+    class="Input__errorMessageWrapper"
+  >
+    <test-file-stub
+      classname="Input__icon"
+      viewbox="0 0 24 24"
+    />
+    <p
+      class="Input__errorMessage"
+    />
+  </div>
   <p
     class="Text--context_critical Text--size_small FieldWithValidation"
   >
@@ -102,12 +138,24 @@ exports[`FieldWithValidation with error message passed should render the message
     for="input-field"
   />
   <input
+    aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
     id="input-field"
     type="text"
     value=""
   />
+  <div
+    class="Input__errorMessageWrapper"
+  >
+    <test-file-stub
+      classname="Input__icon"
+      viewbox="0 0 24 24"
+    />
+    <p
+      class="Input__errorMessage"
+    />
+  </div>
   <p
     class="Text--context_critical Text--size_small FieldWithValidation"
   >
@@ -123,12 +171,24 @@ exports[`FieldWithValidation with error message passed should set context to bad
     for="input-field"
   />
   <input
+    aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
     id="input-field"
     type="text"
     value=""
   />
+  <div
+    class="Input__errorMessageWrapper"
+  >
+    <test-file-stub
+      classname="Input__icon"
+      viewbox="0 0 24 24"
+    />
+    <p
+      class="Input__errorMessage"
+    />
+  </div>
   <p
     class="Text--context_critical Text--size_small FieldWithValidation"
   >

--- a/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
+++ b/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
@@ -2,9 +2,14 @@
 
 exports[`FieldWithValidation when rendering message as text with no error message passed should simply render the child as it is 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for="input-field"
+  />
   <input
-    class="Input"
+    class="Input Input--size_medium"
     data-lpignore="true"
+    id="input-field"
     type="text"
     value=""
   />
@@ -13,9 +18,14 @@ exports[`FieldWithValidation when rendering message as text with no error messag
 
 exports[`FieldWithValidation when using tooltip when error message is defined should remove the message when field is blurred 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for="input-field"
+  />
   <input
-    class="Input Input--context_critical"
+    class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
+    id="input-field"
     type="text"
     value=""
   />
@@ -29,9 +39,14 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
 
 exports[`FieldWithValidation when using tooltip when error message is defined should render the message when field is focused 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for="input-field"
+  />
   <input
-    class="Input Input--context_critical"
+    class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
+    id="input-field"
     type="text"
     value=""
   />
@@ -45,9 +60,14 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
 
 exports[`FieldWithValidation when using tooltip when error message is defined should set context to bad on child 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for="input-field"
+  />
   <input
-    class="Input Input--context_critical"
+    class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
+    id="input-field"
     type="text"
     value=""
   />
@@ -61,9 +81,14 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
 
 exports[`FieldWithValidation when using tooltip with no error message passed should not render a tooltip with no error message 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for="input-field"
+  />
   <input
-    class="Input"
+    class="Input Input--size_medium"
     data-lpignore="true"
+    id="input-field"
     type="text"
     value=""
   />
@@ -72,9 +97,14 @@ exports[`FieldWithValidation when using tooltip with no error message passed sho
 
 exports[`FieldWithValidation with error message passed should render the message as text 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for="input-field"
+  />
   <input
-    class="Input Input--context_critical"
+    class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
+    id="input-field"
     type="text"
     value=""
   />
@@ -88,9 +118,14 @@ exports[`FieldWithValidation with error message passed should render the message
 
 exports[`FieldWithValidation with error message passed should set context to bad on child 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for="input-field"
+  />
   <input
-    class="Input Input--context_critical"
+    class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
+    id="input-field"
     type="text"
     value=""
   />

--- a/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
+++ b/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`FieldWithValidation when rendering message as text with no error messag
   <input
     class="Input Input--size_medium"
     data-lpignore="true"
-    id="input-field"
+    id=":r0:"
     type="text"
     value=""
   />
@@ -18,7 +18,7 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
     aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
-    id="input-field"
+    id=":r6:"
     type="text"
     value=""
   />
@@ -36,7 +36,7 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
     aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
-    id="input-field"
+    id=":r5:"
     type="text"
     value=""
   />
@@ -54,7 +54,7 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
     aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
-    id="input-field"
+    id=":r4:"
     type="text"
     value=""
   />
@@ -71,7 +71,7 @@ exports[`FieldWithValidation when using tooltip with no error message passed sho
   <input
     class="Input Input--size_medium"
     data-lpignore="true"
-    id="input-field"
+    id=":r3:"
     type="text"
     value=""
   />
@@ -84,7 +84,7 @@ exports[`FieldWithValidation with error message passed should render the message
     aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
-    id="input-field"
+    id=":r2:"
     type="text"
     value=""
   />
@@ -102,7 +102,7 @@ exports[`FieldWithValidation with error message passed should set context to bad
     aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
-    id="input-field"
+    id=":r1:"
     type="text"
     value=""
   />

--- a/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
+++ b/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
@@ -30,17 +30,6 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
     type="text"
     value=""
   />
-  <div
-    class="Input__errorMessageWrapper"
-  >
-    <test-file-stub
-      classname="Input__icon"
-      viewbox="0 0 24 24"
-    />
-    <p
-      class="Input__errorMessage"
-    />
-  </div>
   <p
     class="Text--context_critical Text--size_small FieldWithValidation"
   >
@@ -63,17 +52,6 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
     type="text"
     value=""
   />
-  <div
-    class="Input__errorMessageWrapper"
-  >
-    <test-file-stub
-      classname="Input__icon"
-      viewbox="0 0 24 24"
-    />
-    <p
-      class="Input__errorMessage"
-    />
-  </div>
   <p
     class="Text--context_critical Text--size_small FieldWithValidation"
   >
@@ -96,17 +74,6 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
     type="text"
     value=""
   />
-  <div
-    class="Input__errorMessageWrapper"
-  >
-    <test-file-stub
-      classname="Input__icon"
-      viewbox="0 0 24 24"
-    />
-    <p
-      class="Input__errorMessage"
-    />
-  </div>
   <p
     class="Text--context_critical Text--size_small FieldWithValidation"
   >
@@ -145,17 +112,6 @@ exports[`FieldWithValidation with error message passed should render the message
     type="text"
     value=""
   />
-  <div
-    class="Input__errorMessageWrapper"
-  >
-    <test-file-stub
-      classname="Input__icon"
-      viewbox="0 0 24 24"
-    />
-    <p
-      class="Input__errorMessage"
-    />
-  </div>
   <p
     class="Text--context_critical Text--size_small FieldWithValidation"
   >
@@ -178,17 +134,6 @@ exports[`FieldWithValidation with error message passed should set context to bad
     type="text"
     value=""
   />
-  <div
-    class="Input__errorMessageWrapper"
-  >
-    <test-file-stub
-      classname="Input__icon"
-      viewbox="0 0 24 24"
-    />
-    <p
-      class="Input__errorMessage"
-    />
-  </div>
   <p
     class="Text--context_critical Text--size_small FieldWithValidation"
   >

--- a/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
+++ b/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
@@ -2,10 +2,6 @@
 
 exports[`FieldWithValidation when rendering message as text with no error message passed should simply render the child as it is 1`] = `
 <div>
-  <label
-    class="Input__label"
-    for="input-field"
-  />
   <input
     class="Input Input--size_medium"
     data-lpignore="true"
@@ -18,10 +14,6 @@ exports[`FieldWithValidation when rendering message as text with no error messag
 
 exports[`FieldWithValidation when using tooltip when error message is defined should remove the message when field is blurred 1`] = `
 <div>
-  <label
-    class="Input__label"
-    for="input-field"
-  />
   <input
     aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
@@ -40,10 +32,6 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
 
 exports[`FieldWithValidation when using tooltip when error message is defined should render the message when field is focused 1`] = `
 <div>
-  <label
-    class="Input__label"
-    for="input-field"
-  />
   <input
     aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
@@ -62,10 +50,6 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
 
 exports[`FieldWithValidation when using tooltip when error message is defined should set context to bad on child 1`] = `
 <div>
-  <label
-    class="Input__label"
-    for="input-field"
-  />
   <input
     aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
@@ -84,10 +68,6 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
 
 exports[`FieldWithValidation when using tooltip with no error message passed should not render a tooltip with no error message 1`] = `
 <div>
-  <label
-    class="Input__label"
-    for="input-field"
-  />
   <input
     class="Input Input--size_medium"
     data-lpignore="true"
@@ -100,10 +80,6 @@ exports[`FieldWithValidation when using tooltip with no error message passed sho
 
 exports[`FieldWithValidation with error message passed should render the message as text 1`] = `
 <div>
-  <label
-    class="Input__label"
-    for="input-field"
-  />
   <input
     aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"
@@ -122,10 +98,6 @@ exports[`FieldWithValidation with error message passed should render the message
 
 exports[`FieldWithValidation with error message passed should set context to bad on child 1`] = `
 <div>
-  <label
-    class="Input__label"
-    for="input-field"
-  />
   <input
     aria-invalid="true"
     class="Input Input--context_critical Input--size_medium"

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -1,10 +1,11 @@
 .Input {
     border: {
-        color: var(--color-neutral-20);
+        color: var(--color-border-input);
         radius: var(--space-100);
         style: solid;
         width: var(--line-normal);
     }
+    background-color: var(--color-background-input-default);
     box-sizing: border-box;
     composes: OneUI-label-text from global;
 

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -50,11 +50,27 @@
         &_small {
             padding: var(--space-75) var(--space-100);
             height: 32px;
+
+            &:focus:not(.Input--context_critical):not([readOnly]) {
+                padding: var(--space-75) calc(var(--space-100) - 1px);
+            }
+
+            &.Input--context_critical {
+                padding: var(--space-75) calc(var(--space-100) - 1px);
+            }
         }
 
         &_medium {
             padding: calc(var(--space-25) * 5) var(--space-150);
             height: 40px;
+
+            &:focus:not(.Input--context_critical):not([readOnly]) {
+                padding: calc(var(--space-25) * 5) calc(var(--space-150) - 1px);
+            }
+
+            &.Input--context_critical {
+                padding: calc(var(--space-25) * 5) calc(var(--space-150) - 1px);
+            }
         }
     }
 

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -1,12 +1,12 @@
-@import '../../themes/oneui/placeholders/input';
-@import '../../themes/oneui/constants/colors';
-
 .Input {
-    @extend %input;
-
-    border-color: var(--color-neutral-20);
-    border-radius: var(--space-100);
-    font-size: var(--font-size-small);
+    border: {
+        color: var(--color-neutral-20);
+        radius: var(--space-100);
+        style: solid;
+        width: var(--line-normal);
+    }
+    box-sizing: border-box;
+    composes: OneUI-label-text from global;
 
     &::placeholder {
         color: var(--color-text-subtlest);
@@ -25,13 +25,15 @@
 
     &:focus {
         background-color: inherit;
-        border: 1px solid var(--color-info-20);
+        border: 1px solid var(--color-neutral-20);
+        outline: 1px solid var(--color-info-20);
     }
 
     &[disabled] {
         background-color: var(--color-background-input-default);
         color: var(--color-text-disabled);
         border: 1px solid var(--color-border-disabled);
+        cursor: not-allowed;
 
         &::placeholder {
             color: var(--color-text-disabled);
@@ -57,11 +59,13 @@
 
     &--isActive {
         border: 2px solid var(--color-border-selected);
+        outline: none;
 
         &:hover,
         &:focus {
             border: 2px solid var(--color-border-selected);
             background-color: inherit;
+            outline: none;
         }
     }
 
@@ -69,13 +73,11 @@
         &_small {
             padding: var(--space-75) var(--space-100);
             height: 32px;
-            line-height: var(--line-height-small);
         }
 
         &_medium {
             padding: calc(var(--space-25) * 5) var(--space-150);
             height: 40px;
-            line-height: var(--line-height-large);
         }
     }
 
@@ -93,9 +95,7 @@
     &__label {
         margin-bottom: var(--space-50);
         padding: 0 var(--space-50);
-        font-size: var(--font-size-x-small);
-        font-weight: var(--font-weight-bold);
-        line-height: var(--line-height-x-small);
+        composes: OneUI-caption-text-bold from global;
         display: block;
     }
 
@@ -109,16 +109,14 @@
 
     &__errorMessage {
         margin: 0;
-        font-size: var(--font-size-x-small);
-        line-height: var(--line-height-x-small);
+        composes: OneUI-caption-text from global;
         color: var(--color-text-critical-default);
     }
 
     &__helperText {
         margin: var(--space-50) 0 0;
         padding: 0 var(--space-50);
-        font-size: var(--font-size-x-small);
-        line-height: var(--line-height-x-small);
+        composes: OneUI-caption-text from global;
         color: var(--color-text-subtlest);
     }
 

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -85,7 +85,7 @@
         gap: var(--space-25);
         align-items: center;
 
-        &--reserveErrorSpace {
+        &--reserveErrorMessageSpace {
             min-height: 16px;
             box-sizing: content-box;
         }

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -95,6 +95,15 @@
         margin: 0;
         composes: OneUI-caption-text from global;
         color: var(--color-text-critical-default);
+
+        &--reserveErrorMessageSpace {
+            display: none;
+        }
+
+        &--context_critical,
+        &:invalid {
+            display: block;
+        }
     }
 
     &__helperText {
@@ -108,5 +117,14 @@
         width: 16px;
         height: 16px;
         fill: var(--color-icon-critical-default);
+
+        &--reserveErrorMessageSpace {
+            display: none;
+        }
+
+        &--context_critical,
+        &:invalid {
+            display: block;
+        }
     }
 }

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -26,8 +26,8 @@
 
     &:focus {
         background-color: inherit;
-        border: 1px solid var(--color-neutral-20);
-        outline: 1px solid var(--color-info-20);
+        border: 2px solid var(--color-border-selected);
+        outline: none;
     }
 
     &[disabled] {
@@ -39,35 +39,11 @@
         &::placeholder {
             color: var(--color-text-disabled);
         }
-
-        &:hover,
-        &:focus {
-            background-color: var(--color-background-input-default);
-            border: 1px solid var(--color-border-disabled);
-        }
     }
 
     &[readOnly] {
         background-color: var(--color-background-input-read-only);
         border: none;
-
-        &:hover,
-        &:focus {
-            background-color: var(--color-background-input-read-only);
-            border: none;
-        }
-    }
-
-    &--isActive {
-        border: 2px solid var(--color-border-selected);
-        outline: none;
-
-        &:hover,
-        &:focus {
-            border: 2px solid var(--color-border-selected);
-            background-color: inherit;
-            outline: none;
-        }
     }
 
     &--size {

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -84,11 +84,13 @@
     &--context_critical,
     &:invalid {
         border: 2px solid var(--color-border-critical-bold-default);
+        outline: none;
 
         &:focus,
         &:hover {
             border: 2px solid var(--color-border-critical-bold-default);
             background-color: inherit;
+            outline: none;
         }
     }
 

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -78,7 +78,7 @@
         display: block;
     }
 
-    &__messageWrapper {
+    &__errorMessageWrapper {
         margin-top: var(--space-50);
         padding: 0 var(--space-50);
         display: flex;

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -78,12 +78,17 @@
         display: block;
     }
 
-    &__errorMessageWrapper {
+    &__messageWrapper {
         margin-top: var(--space-50);
         padding: 0 var(--space-50);
         display: flex;
         gap: var(--space-25);
         align-items: center;
+
+        &--reserveErrorSpace {
+            min-height: 16px;
+            box-sizing: content-box;
+        }
     }
 
     &__errorMessage {

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -5,20 +5,12 @@
     @extend %input;
 
     border-color: var(--color-neutral-20);
-
-    &--context {
-        @each $context in ($contexts) {
-            &_#{ $context } {
-                border-color: var(--color-#{$context}-50);
-                &:focus {
-                    border-color: var(--color-#{$context}-50);
-                }
-            }
-        }
-    }
+    border-radius: var(--space-100);
+    font-size: var(--font-size-small);
 
     &::placeholder {
-        color: var(--color-neutral-30);
+        color: var(--color-text-subtlest);
+        line-height: var(--line-height-small);
         opacity: 1;
     }
 
@@ -26,22 +18,111 @@
         width: 100%;
     }
 
+    &:hover {
+        background-color: var(--color-background-input-hover);
+        border: 1px solid var(--color-border-input);
+    }
+
+    &:focus {
+        background-color: inherit;
+        border: 1px solid var(--color-info-20);
+    }
+
     &[disabled] {
-        background-color: var(--color-background);
+        background-color: var(--color-background-input-default);
+        color: var(--color-text-disabled);
+        border: 1px solid var(--color-border-disabled);
+
+        &::placeholder {
+            color: var(--color-text-disabled);
+        }
+
+        &:hover,
+        &:focus {
+            background-color: var(--color-background-input-default);
+            border: 1px solid var(--color-border-disabled);
+        }
+    }
+
+    &[readOnly] {
+        background-color: var(--color-background-input-read-only);
+        border: none;
+
+        &:hover,
+        &:focus {
+            background-color: var(--color-background-input-read-only);
+            border: none;
+        }
+    }
+
+    &--isActive {
+        border: 2px solid var(--color-border-selected);
+
+        &:hover,
+        &:focus {
+            border: 2px solid var(--color-border-selected);
+            background-color: inherit;
+        }
     }
 
     &--size {
         &_small {
-            min-height: 26px;
-            height: 26px;
-            font-size: var(--font-size-small);
+            min-height: 32px;
+            height: 32px;
             line-height: var(--line-height-small);
-            padding: var(--space-50);
+            padding: var(--space-75) var(--space-100);
         }
-        &_large {
-            font-size: var(--font-size-large);
+
+        &_medium {
+            height: 40px;
             line-height: var(--line-height-large);
-            padding: var(--space-100);
+            padding: calc(var(--space-25) * 5) var(--space-150);
         }
+    }
+
+    &--context_critical,
+    &:invalid {
+        border: 2px solid var(--color-border-critical-bold-default);
+
+        &:focus,
+        &:hover {
+            border: 2px solid var(--color-border-critical-bold-default);
+            background-color: inherit;
+        }
+    }
+
+    &__label {
+        padding: 0 var(--space-50);
+        font-size: var(--font-size-x-small);
+        font-weight: var(--font-weight-bold);
+        line-height: var(--line-height-x-small);
+        display: block;
+        margin-bottom: var(--space-50);
+    }
+
+    &__helperTextWrapper {
+        display: flex;
+        margin-top: var(--space-50);
+        padding: 0 var(--space-50);
+        gap: var(--space-25);
+        align-items: center;
+    }
+
+    &__helperText {
+        font-size: var(--font-size-x-small);
+        line-height: var(--line-height-x-small);
+        color: var(--color-text-subtlest);
+        margin: 0;
+
+        &--context_critical,
+        &:invalid & {
+            color: var(--color-text-critical-default);
+        }
+    }
+
+    &__icon {
+        width: 16px;
+        height: 16px;
+        fill: var(--color-icon-critical-default);
     }
 }

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -67,16 +67,15 @@
 
     &--size {
         &_small {
-            min-height: 32px;
+            padding: var(--space-75) var(--space-100);
             height: 32px;
             line-height: var(--line-height-small);
-            padding: var(--space-75) var(--space-100);
         }
 
         &_medium {
+            padding: calc(var(--space-25) * 5) var(--space-150);
             height: 40px;
             line-height: var(--line-height-large);
-            padding: calc(var(--space-25) * 5) var(--space-150);
         }
     }
 
@@ -92,32 +91,35 @@
     }
 
     &__label {
+        margin-bottom: var(--space-50);
         padding: 0 var(--space-50);
         font-size: var(--font-size-x-small);
         font-weight: var(--font-weight-bold);
         line-height: var(--line-height-x-small);
         display: block;
-        margin-bottom: var(--space-50);
     }
 
-    &__helperTextWrapper {
-        display: flex;
+    &__errorMessageWrapper {
         margin-top: var(--space-50);
         padding: 0 var(--space-50);
+        display: flex;
         gap: var(--space-25);
         align-items: center;
     }
 
+    &__errorMessage {
+        margin: 0;
+        font-size: var(--font-size-x-small);
+        line-height: var(--line-height-x-small);
+        color: var(--color-text-critical-default);
+    }
+
     &__helperText {
+        margin: var(--space-50) 0 0;
+        padding: 0 var(--space-50);
         font-size: var(--font-size-x-small);
         line-height: var(--line-height-x-small);
         color: var(--color-text-subtlest);
-        margin: 0;
-
-        &--context_critical,
-        &:invalid & {
-            color: var(--color-text-critical-default);
-        }
     }
 
     &__icon {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -4,7 +4,7 @@ import { bem } from '../../utils';
 import styles from './Input.scss';
 import { InputType } from '../../constants';
 
-type FieldSize = 'small' | 'medium';
+type InputSize = 'small' | 'medium';
 
 type ErrorContext = 'critical';
 
@@ -23,7 +23,7 @@ interface BaseProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 's
     /** Whether or not to show block-level input field (full width) */
     isBlock?: boolean;
     /** The size of the input field */
-    size?: FieldSize;
+    size?: InputSize;
     /** Type of the input field */
     type?: InputType;
     /** Field label */

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -68,9 +68,11 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
 
         return (
             <>
-                <label {...elem('label')} htmlFor="input-field">
-                    {label}
-                </label>
+                {label && (
+                    <label {...elem('label')} htmlFor="input-field">
+                        {label}
+                    </label>
+                )}
                 <input
                     {...rest}
                     {...block({ context, size, isBlock, disabled, isActive, ...rest })}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import * as React from 'react';
 import Error from '@material-design-icons/svg/round/error.svg';
 import { bem } from '../../utils';
@@ -30,6 +31,9 @@ interface BaseProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 's
     label?: string;
     /** Helper text under the input, display the error when the context is critical */
     helperText?: string;
+    /**  Controls whether space is reserved for error messages under the input field when validation is expected
+     *  to avoid "jumping" UI. */
+    reserveErrorSpace?: boolean;
 }
 
 export type Props = BaseProps & (ErrorStateProps | { context?: undefined; errorMessage?: never });
@@ -51,6 +55,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
             label,
             helperText,
             errorMessage,
+            reserveErrorSpace = false,
             ...rest
         },
         ref
@@ -79,11 +84,14 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
                     aria-invalid={context === 'critical' ? 'true' : undefined}
                     data-lpignore={isLastPassDisabled}
                 />
+
                 {context === 'critical' && errorMessage ? (
-                    <div {...elem('errorMessageWrapper')}>
+                    <div {...elem('messageWrapper')}>
                         <Error viewBox="0 0 24 24" {...elem('icon')} />
                         <p {...elem('errorMessage', { context })}>{errorMessage}</p>
                     </div>
+                ) : reserveErrorSpace && !helperText ? (
+                    <div {...elem('messageWrapper', { reserveErrorSpace })} />
                 ) : (
                     helperText && <p {...elem('helperText')}>{helperText}</p>
                 )}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -10,7 +10,7 @@ type ErrorContext = 'critical';
 
 type ErrorStateProps = {
     /** The input error field context (critical) */
-    context?: ErrorContext;
+    context: ErrorContext;
     /** This message will be rendered under the input when context critical will be applied */
     errorMessage: string;
 };

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -55,20 +55,10 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
         },
         ref
     ) => {
-        const [isActive, setIsActive] = React.useState(false);
-
         const fallbackId = React.useId();
         const idRef = id || fallbackId;
 
         const isLastPassDisabled = type !== 'password';
-
-        const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
-            setIsActive(event.target.value.length > 0);
-        };
-
-        const handleOnBlur = () => {
-            setIsActive(false);
-        };
 
         return (
             <>
@@ -79,15 +69,13 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
                 )}
                 <input
                     {...rest}
-                    {...block({ context, size, isBlock, disabled, isActive, ...rest })}
+                    {...block({ context, size, isBlock, disabled, ...rest })}
                     id={idRef}
                     ref={ref}
                     type={type}
                     disabled={disabled}
                     readOnly={readOnly}
                     value={value}
-                    onInput={handleInput}
-                    onBlur={handleOnBlur}
                     aria-invalid={context === 'critical' ? 'true' : undefined}
                     data-lpignore={isLastPassDisabled}
                 />

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,24 +1,35 @@
 import * as React from 'react';
+import Error from '@material-design-icons/svg/round/error.svg';
 import { bem } from '../../utils';
 import styles from './Input.scss';
-import { ValidationContext, InputType, OldSize as Size } from '../../constants';
+import { InputType } from '../../constants';
+
+type FieldSize = 'small' | 'medium';
+
+type ErrorContext = 'critical';
 
 // Any other attributes (onChange, onKeyUp etc.) are
 // supported although not defined in props type definition
 export interface Props extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
-    /** The input field context (e.g. brand, critical, success etc. - defaults to brand) */
-    context?: ValidationContext;
+    /** The input error field context (critical) */
+    context?: ErrorContext;
     /** Should the input field be disabled or not */
     disabled?: boolean;
+    /** Should the input field be readOnly or not */
+    readOnly?: boolean;
     /** Whether or not to show block-level input field (full width) */
     isBlock?: boolean;
     /** The size of the input field */
-    size?: Size;
+    size?: FieldSize;
     /** Type of the input field */
     type?: InputType;
+    /** Field label */
+    label?: string;
+    /** Helper text under the field, display the error when the context is critical */
+    helperText?: string;
 }
 
-const { block } = bem('Input', styles);
+const { block, elem } = bem('Input', styles);
 
 export const Input = React.forwardRef<HTMLInputElement, Props>(
     (
@@ -26,25 +37,55 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
             children,
             context,
             disabled = false,
+            readOnly = false,
             isBlock = false,
-            size = 'normal',
+            size = 'medium',
             type = 'text',
             value,
+            label,
+            helperText,
             ...rest
         },
         ref
     ) => {
+        const [isActive, setIsActive] = React.useState(false);
+
         const isLastPassDisabled = type !== 'password';
+
+        const handleInput = (event) => {
+            setIsActive(event.target.value.length > 0);
+        };
+
+        const handleOnBlur = () => {
+            setIsActive(false);
+        };
+
         return (
-            <input
-                {...rest}
-                {...block({ context, size, isBlock, disabled, ...rest })}
-                ref={ref}
-                type={type}
-                disabled={disabled}
-                value={value}
-                data-lpignore={isLastPassDisabled}
-            />
+            <>
+                <label {...elem('label')} htmlFor="input-field">
+                    {label}
+                </label>
+                <input
+                    {...rest}
+                    {...block({ context, size, isBlock, disabled, isActive, ...rest })}
+                    id="input-field"
+                    ref={ref}
+                    type={type}
+                    disabled={disabled}
+                    readOnly={readOnly}
+                    value={value}
+                    onInput={handleInput}
+                    onBlur={handleOnBlur}
+                    data-lpignore={isLastPassDisabled}
+                />
+
+                {helperText && (
+                    <div {...elem('helperTextWrapper')}>
+                        {context && <Error viewBox="0 0 24 24" {...elem('icon')} />}
+                        <p {...elem('helperText', { context })}>{helperText}</p>
+                    </div>
+                )}
+            </>
         );
     }
 );

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -86,12 +86,12 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
                 />
 
                 {context === 'critical' && errorMessage ? (
-                    <div {...elem('messageWrapper')}>
+                    <div {...elem('errorMessageWrapper')}>
                         <Error viewBox="0 0 24 24" {...elem('icon')} />
                         <p {...elem('errorMessage', { context })}>{errorMessage}</p>
                     </div>
                 ) : reserveErrorSpace && !helperText ? (
-                    <div {...elem('messageWrapper', { reserveErrorSpace })} />
+                    <div {...elem('errorMessageWrapper', { reserveErrorSpace })} />
                 ) : (
                     helperText && <p {...elem('helperText')}>{helperText}</p>
                 )}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -33,7 +33,7 @@ interface BaseProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 's
     helperText?: string;
     /**  Controls whether space is reserved for error messages under the input field when validation is expected
      *  to avoid "jumping" UI. */
-    reserveErrorSpace?: boolean;
+    reserveErrorMessageSpace?: boolean;
 }
 
 export type Props = BaseProps & (ErrorStateProps | { context?: undefined; errorMessage?: never });
@@ -55,7 +55,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
             label,
             helperText,
             errorMessage,
-            reserveErrorSpace = false,
+            reserveErrorMessageSpace = false,
             ...rest
         },
         ref
@@ -90,8 +90,8 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
                         <Error viewBox="0 0 24 24" {...elem('icon')} />
                         <p {...elem('errorMessage', { context })}>{errorMessage}</p>
                     </div>
-                ) : reserveErrorSpace && !helperText ? (
-                    <div {...elem('errorMessageWrapper', { reserveErrorSpace })} />
+                ) : reserveErrorMessageSpace && !helperText ? (
+                    <div {...elem('errorMessageWrapper', { reserveErrorMessageSpace })} />
                 ) : (
                     helperText && <p {...elem('helperText')}>{helperText}</p>
                 )}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -39,6 +39,7 @@ const { block, elem } = bem('Input', styles);
 export const Input = React.forwardRef<HTMLInputElement, Props>(
     (
         {
+            id,
             children,
             context = undefined,
             disabled = false,
@@ -56,7 +57,8 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
     ) => {
         const [isActive, setIsActive] = React.useState(false);
 
-        const idRef = React.useId();
+        const fallbackId = React.useId(); // More descriptive name for generated ID
+        const idRef = id || fallbackId;
 
         const isLastPassDisabled = type !== 'password';
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import * as React from 'react';
 import Error from '@material-design-icons/svg/round/error.svg';
 import { bem } from '../../utils';
@@ -85,13 +84,15 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
                     data-lpignore={isLastPassDisabled}
                 />
 
+                {context !== 'critical' && reserveErrorMessageSpace && !helperText && (
+                    <div {...elem('errorMessageWrapper', { reserveErrorMessageSpace })} />
+                )}
+
                 {context === 'critical' && errorMessage ? (
                     <div {...elem('errorMessageWrapper')}>
                         <Error viewBox="0 0 24 24" {...elem('icon')} />
                         <p {...elem('errorMessage', { context })}>{errorMessage}</p>
                     </div>
-                ) : reserveErrorMessageSpace && !helperText ? (
-                    <div {...elem('errorMessageWrapper', { reserveErrorMessageSpace })} />
                 ) : (
                     helperText && <p {...elem('helperText')}>{helperText}</p>
                 )}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -32,7 +32,7 @@ interface BaseProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 's
     helperText?: string;
 }
 
-export type Props = BaseProps & (ErrorStateProps | { context?: never; errorMessage?: never });
+export type Props = BaseProps & (ErrorStateProps | { context?: undefined; errorMessage?: never });
 
 const { block, elem } = bem('Input', styles);
 
@@ -40,7 +40,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
     (
         {
             children,
-            context,
+            context = undefined,
             disabled = false,
             readOnly = false,
             isBlock = false,

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -84,14 +84,21 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
                     data-lpignore={isLastPassDisabled}
                 />
 
-                {context !== 'critical' && reserveErrorMessageSpace && !helperText && (
-                    <div {...elem('errorMessageWrapper', { reserveErrorMessageSpace })} />
-                )}
-
-                {context === 'critical' && errorMessage ? (
-                    <div {...elem('errorMessageWrapper')}>
-                        <Error viewBox="0 0 24 24" {...elem('icon')} />
-                        <p {...elem('errorMessage', { context })}>{errorMessage}</p>
+                {(context === 'critical' && errorMessage) ||
+                (reserveErrorMessageSpace && !helperText) ? (
+                    <div {...elem('errorMessageWrapper', { reserveErrorMessageSpace })}>
+                        <Error
+                            viewBox="0 0 24 24"
+                            {...elem('icon', { context, reserveErrorMessageSpace })}
+                        />
+                        <p
+                            {...elem('errorMessage', {
+                                context,
+                                reserveErrorMessageSpace,
+                            })}
+                        >
+                            {errorMessage}
+                        </p>
                     </div>
                 ) : (
                     helperText && <p {...elem('helperText')}>{helperText}</p>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -57,7 +57,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
     ) => {
         const [isActive, setIsActive] = React.useState(false);
 
-        const fallbackId = React.useId(); // More descriptive name for generated ID
+        const fallbackId = React.useId();
         const idRef = id || fallbackId;
 
         const isLastPassDisabled = type !== 'password';

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -56,6 +56,8 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
     ) => {
         const [isActive, setIsActive] = React.useState(false);
 
+        const idRef = React.useId();
+
         const isLastPassDisabled = type !== 'password';
 
         const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -69,14 +71,14 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
         return (
             <>
                 {label && (
-                    <label {...elem('label')} htmlFor="input-field">
+                    <label {...elem('label')} htmlFor={idRef}>
                         {label}
                     </label>
                 )}
                 <input
                     {...rest}
                     {...block({ context, size, isBlock, disabled, isActive, ...rest })}
-                    id="input-field"
+                    id={idRef}
                     ref={ref}
                     type={type}
                     disabled={disabled}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -85,7 +85,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
                     aria-invalid={context === 'critical' ? 'true' : undefined}
                     data-lpignore={isLastPassDisabled}
                 />
-                {context === 'critical' ? (
+                {context === 'critical' && errorMessage ? (
                     <div {...elem('errorMessageWrapper')}>
                         <Error viewBox="0 0 24 24" {...elem('icon')} />
                         <p {...elem('errorMessage', { context })}>{errorMessage}</p>

--- a/src/components/Input/__tests__/Input.spec.tsx
+++ b/src/components/Input/__tests__/Input.spec.tsx
@@ -18,15 +18,40 @@ describe('<Input> that renders an input field', () => {
     });
 
     it('should add classes when props are changed', () => {
-        view = render(<Input context="critical" size="large" isBlock disabled />);
+        view = render(<Input context="critical" isBlock disabled />);
         const textbox = screen.getByRole('textbox');
 
         expect(view.container).toMatchSnapshot();
         expect(textbox).toBeInTheDocument();
         expect(textbox).toHaveClass(
-            'Input Input--context_critical Input--size_large Input--isBlock'
+            'Input Input--context_critical Input--size_medium Input--isBlock'
         );
         expect(textbox).toHaveAttribute('disabled');
+    });
+
+    it('should render input with label', () => {
+        const label = 'Input Label';
+        view = render(<Input label={label} />);
+        const labelText = screen.getByText(label);
+
+        expect(labelText).toBeInTheDocument();
+        expect(labelText).toHaveAttribute('for', 'input-field');
+    });
+
+    it('should show helper text when provided', () => {
+        const helperText = 'This is helper text';
+        view = render(<Input helperText={helperText} context="critical" />);
+        const helperTextElement = screen.getByText(helperText);
+
+        expect(helperTextElement).toBeInTheDocument();
+        expect(helperTextElement).toHaveClass('Input__helperText--context_critical');
+    });
+
+    it('should handle readOnly state correctly', () => {
+        view = render(<Input readOnly />);
+        const textbox = screen.getByRole('textbox');
+
+        expect(textbox).toHaveAttribute('readOnly');
     });
 
     it('should call change callback correctly', async () => {

--- a/src/components/Input/__tests__/Input.spec.tsx
+++ b/src/components/Input/__tests__/Input.spec.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { render, RenderResult, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { InputProps } from '@textkernel/oneui';
-import { Input } from '../Input';
+import { Input, Props } from '../Input';
 
-const defaultProps: InputProps = {
+const defaultProps: Props = {
     label: 'Input Label',
     type: 'text',
     helperText: 'This is a helper text',
@@ -49,7 +48,7 @@ describe('<Input> that renders an input field', () => {
         const labelText = screen.getByText(label);
 
         expect(labelText).toBeInTheDocument();
-        expect(labelText).toHaveAttribute('for', 'input-field');
+        expect(screen.getByLabelText(label)).toBeInTheDocument();
     });
 
     it('should show helper text when provided', () => {

--- a/src/components/Input/__tests__/Input.spec.tsx
+++ b/src/components/Input/__tests__/Input.spec.tsx
@@ -2,14 +2,24 @@ import React from 'react';
 import { render, RenderResult, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import { InputProps } from '@textkernel/oneui';
 import { Input } from '../Input';
+
+const defaultProps: InputProps = {
+    label: 'Input Label',
+    type: 'text',
+    helperText: 'This is a helper text',
+    context: undefined,
+};
+
+const renderComponent = (props = {}) => render(<Input {...defaultProps} {...props} />);
 
 describe('<Input> that renders an input field', () => {
     let view: RenderResult;
 
     it('should render default input correctly', () => {
         const onChange = jest.fn();
-        view = render(<Input value="Some value" onChange={onChange} />);
+        view = renderComponent({ value: 'Some value', onChange });
         const textbox = screen.getByRole('textbox');
 
         expect(view.container).toMatchSnapshot();
@@ -18,7 +28,11 @@ describe('<Input> that renders an input field', () => {
     });
 
     it('should add classes when props are changed', () => {
-        view = render(<Input context="critical" isBlock disabled />);
+        view = renderComponent({
+            context: 'critical',
+            isBlock: true,
+            disabled: true,
+        });
         const textbox = screen.getByRole('textbox');
 
         expect(view.container).toMatchSnapshot();
@@ -31,7 +45,7 @@ describe('<Input> that renders an input field', () => {
 
     it('should render input with label', () => {
         const label = 'Input Label';
-        view = render(<Input label={label} />);
+        view = renderComponent({ label });
         const labelText = screen.getByText(label);
 
         expect(labelText).toBeInTheDocument();
@@ -40,15 +54,34 @@ describe('<Input> that renders an input field', () => {
 
     it('should show helper text when provided', () => {
         const helperText = 'This is helper text';
-        view = render(<Input helperText={helperText} context="critical" />);
+        view = renderComponent({
+            helperText,
+        });
         const helperTextElement = screen.getByText(helperText);
 
         expect(helperTextElement).toBeInTheDocument();
-        expect(helperTextElement).toHaveClass('Input__helperText--context_critical');
+        expect(helperTextElement).toHaveClass('Input__helperText');
+    });
+
+    it('should display errorMessage instead of helper text when context is critical', () => {
+        const helperText = 'This is helper text';
+        const errorMessage = 'Value is invalid';
+        view = renderComponent({
+            context: 'critical',
+            errorMessage,
+            helperText,
+        });
+
+        const errorMessageElement = screen.getByText(errorMessage);
+        expect(errorMessageElement).toBeInTheDocument();
+        expect(errorMessageElement).toHaveClass('Input__errorMessage');
+
+        expect(screen.queryByText(helperText)).not.toBeInTheDocument();
     });
 
     it('should handle readOnly state correctly', () => {
-        view = render(<Input readOnly />);
+        view = renderComponent({ readOnly: true });
+
         const textbox = screen.getByRole('textbox');
 
         expect(textbox).toHaveAttribute('readOnly');
@@ -57,7 +90,7 @@ describe('<Input> that renders an input field', () => {
     it('should call change callback correctly', async () => {
         const user = userEvent.setup();
         const onChange = jest.fn();
-        view = render(<Input onChange={onChange} />);
+        view = renderComponent({ onChange });
 
         await user.type(screen.getByRole('textbox'), 'test');
 
@@ -65,7 +98,7 @@ describe('<Input> that renders an input field', () => {
     });
 
     it('should add string html attributes correctly', () => {
-        view = render(<Input data-test="something" />);
+        view = renderComponent({ 'data-test': 'something' });
 
         expect(screen.getByRole('textbox')).toHaveAttribute('data-test', 'something');
     });

--- a/src/components/Input/__tests__/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.spec.tsx.snap
@@ -17,17 +17,11 @@ exports[`<Input> that renders an input field should add classes when props are c
     type="text"
     value=""
   />
-  <div
-    class="Input__errorMessageWrapper"
+  <p
+    class="Input__helperText"
   >
-    <test-file-stub
-      classname="Input__icon"
-      viewbox="0 0 24 24"
-    />
-    <p
-      class="Input__errorMessage"
-    />
-  </div>
+    This is a helper text
+  </p>
 </div>
 `;
 

--- a/src/components/Input/__tests__/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`<Input> that renders an input field should add classes when props are c
 <div>
   <label
     class="Input__label"
-    for="input-field"
+    for=":r1:"
   >
     Input Label
   </label>
@@ -13,7 +13,7 @@ exports[`<Input> that renders an input field should add classes when props are c
     class="Input Input--context_critical Input--size_medium Input--isBlock"
     data-lpignore="true"
     disabled=""
-    id="input-field"
+    id=":r1:"
     type="text"
     value=""
   />
@@ -29,14 +29,14 @@ exports[`<Input> that renders an input field should render default input correct
 <div>
   <label
     class="Input__label"
-    for="input-field"
+    for=":r0:"
   >
     Input Label
   </label>
   <input
     class="Input Input--size_medium"
     data-lpignore="true"
-    id="input-field"
+    id=":r0:"
     type="text"
     value="Some value"
   />

--- a/src/components/Input/__tests__/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.spec.tsx.snap
@@ -5,8 +5,11 @@ exports[`<Input> that renders an input field should add classes when props are c
   <label
     class="Input__label"
     for="input-field"
-  />
+  >
+    Input Label
+  </label>
   <input
+    aria-invalid="true"
     class="Input Input--context_critical Input--size_medium Input--isBlock"
     data-lpignore="true"
     disabled=""
@@ -14,6 +17,17 @@ exports[`<Input> that renders an input field should add classes when props are c
     type="text"
     value=""
   />
+  <div
+    class="Input__errorMessageWrapper"
+  >
+    <test-file-stub
+      classname="Input__icon"
+      viewbox="0 0 24 24"
+    />
+    <p
+      class="Input__errorMessage"
+    />
+  </div>
 </div>
 `;
 
@@ -22,7 +36,9 @@ exports[`<Input> that renders an input field should render default input correct
   <label
     class="Input__label"
     for="input-field"
-  />
+  >
+    Input Label
+  </label>
   <input
     class="Input Input--size_medium"
     data-lpignore="true"
@@ -30,5 +46,10 @@ exports[`<Input> that renders an input field should render default input correct
     type="text"
     value="Some value"
   />
+  <p
+    class="Input__helperText"
+  >
+    This is a helper text
+  </p>
 </div>
 `;

--- a/src/components/Input/__tests__/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.spec.tsx.snap
@@ -2,10 +2,15 @@
 
 exports[`<Input> that renders an input field should add classes when props are changed 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for="input-field"
+  />
   <input
-    class="Input Input--context_critical Input--size_large Input--isBlock"
+    class="Input Input--context_critical Input--size_medium Input--isBlock"
     data-lpignore="true"
     disabled=""
+    id="input-field"
     type="text"
     value=""
   />
@@ -14,9 +19,14 @@ exports[`<Input> that renders an input field should add classes when props are c
 
 exports[`<Input> that renders an input field should render default input correctly 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for="input-field"
+  />
   <input
-    class="Input"
+    class="Input Input--size_medium"
     data-lpignore="true"
+    id="input-field"
     type="text"
     value="Some value"
   />

--- a/src/components/Themeroller/ThemeTuner/ItemValue/ColorValue/__tests__/__snapshots__/ColorValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/ColorValue/__tests__/__snapshots__/ColorValue.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`ColorValue component should render component correctly 1`] = `
     <input
       class="Input Input--size_small ColorValue__input"
       data-lpignore="true"
-      id="input-field"
+      id=":r0:"
       role="colorselector"
       type="color"
       value="#fffff"

--- a/src/components/Themeroller/ThemeTuner/ItemValue/ColorValue/__tests__/__snapshots__/ColorValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/ColorValue/__tests__/__snapshots__/ColorValue.spec.tsx.snap
@@ -3,9 +3,14 @@
 exports[`ColorValue component should render component correctly 1`] = `
 <div>
   <span>
+    <label
+      class="Input__label"
+      for="input-field"
+    />
     <input
       class="Input Input--size_small ColorValue__input"
       data-lpignore="true"
+      id="input-field"
       role="colorselector"
       type="color"
       value="#fffff"

--- a/src/components/Themeroller/ThemeTuner/ItemValue/ColorValue/__tests__/__snapshots__/ColorValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/ColorValue/__tests__/__snapshots__/ColorValue.spec.tsx.snap
@@ -3,10 +3,6 @@
 exports[`ColorValue component should render component correctly 1`] = `
 <div>
   <span>
-    <label
-      class="Input__label"
-      for="input-field"
-    />
     <input
       class="Input Input--size_small ColorValue__input"
       data-lpignore="true"

--- a/src/components/Themeroller/ThemeTuner/ItemValue/NumberValue/__tests__/__snapshots__/NumberValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/NumberValue/__tests__/__snapshots__/NumberValue.spec.tsx.snap
@@ -2,10 +2,6 @@
 
 exports[`NumberValue component should render component correctly 1`] = `
 <div>
-  <label
-    class="Input__label"
-    for="input-field"
-  />
   <input
     class="Input Input--size_small"
     data-lpignore="true"

--- a/src/components/Themeroller/ThemeTuner/ItemValue/NumberValue/__tests__/__snapshots__/NumberValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/NumberValue/__tests__/__snapshots__/NumberValue.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`NumberValue component should render component correctly 1`] = `
   <input
     class="Input Input--size_small"
     data-lpignore="true"
-    id="input-field"
+    id=":r0:"
     role="numberselector"
     type="number"
     value="100"

--- a/src/components/Themeroller/ThemeTuner/ItemValue/NumberValue/__tests__/__snapshots__/NumberValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/NumberValue/__tests__/__snapshots__/NumberValue.spec.tsx.snap
@@ -2,9 +2,14 @@
 
 exports[`NumberValue component should render component correctly 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for="input-field"
+  />
   <input
     class="Input Input--size_small"
     data-lpignore="true"
+    id="input-field"
     role="numberselector"
     type="number"
     value="100"

--- a/src/components/Themeroller/ThemeTuner/ItemValue/StringValue/__tests__/__snapshots__/StringValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/StringValue/__tests__/__snapshots__/StringValue.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`StringValue component should render component correctly 1`] = `
   <input
     class="Input Input--size_small"
     data-lpignore="true"
-    id="input-field"
+    id=":r0:"
     type="text"
     value="flex"
   />

--- a/src/components/Themeroller/ThemeTuner/ItemValue/StringValue/__tests__/__snapshots__/StringValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/StringValue/__tests__/__snapshots__/StringValue.spec.tsx.snap
@@ -2,9 +2,14 @@
 
 exports[`StringValue component should render component correctly 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for="input-field"
+  />
   <input
     class="Input Input--size_small"
     data-lpignore="true"
+    id="input-field"
     type="text"
     value="flex"
   />

--- a/src/components/Themeroller/ThemeTuner/ItemValue/StringValue/__tests__/__snapshots__/StringValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/StringValue/__tests__/__snapshots__/StringValue.spec.tsx.snap
@@ -2,10 +2,6 @@
 
 exports[`StringValue component should render component correctly 1`] = `
 <div>
-  <label
-    class="Input__label"
-    for="input-field"
-  />
   <input
     class="Input Input--size_small"
     data-lpignore="true"

--- a/src/components/Themeroller/ThemeTuner/ItemValue/UnitValue/__tests__/__snapshots__/UnitValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/UnitValue/__tests__/__snapshots__/UnitValue.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`UnitValue component should render component correctly 1`] = `
     <input
       class="Input Input--size_small UnitValue__input"
       data-lpignore="true"
-      id="input-field"
+      id=":r0:"
       type="number"
       value="12"
     />

--- a/src/components/Themeroller/ThemeTuner/ItemValue/UnitValue/__tests__/__snapshots__/UnitValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/UnitValue/__tests__/__snapshots__/UnitValue.spec.tsx.snap
@@ -3,10 +3,6 @@
 exports[`UnitValue component should render component correctly 1`] = `
 <div>
   <span>
-    <label
-      class="Input__label"
-      for="input-field"
-    />
     <input
       class="Input Input--size_small UnitValue__input"
       data-lpignore="true"

--- a/src/components/Themeroller/ThemeTuner/ItemValue/UnitValue/__tests__/__snapshots__/UnitValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/UnitValue/__tests__/__snapshots__/UnitValue.spec.tsx.snap
@@ -3,9 +3,14 @@
 exports[`UnitValue component should render component correctly 1`] = `
 <div>
   <span>
+    <label
+      class="Input__label"
+      for="input-field"
+    />
     <input
       class="Input Input--size_small UnitValue__input"
       data-lpignore="true"
+      id="input-field"
       type="number"
       value="12"
     />

--- a/src/components/Themeroller/ThemeTuner/__tests__/__snapshots__/ThemeTuner.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/__tests__/__snapshots__/ThemeTuner.spec.tsx.snap
@@ -40,10 +40,6 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           Background color
         </p>
         <span>
-          <label
-            class="Input__label"
-            for="input-field"
-          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
@@ -67,10 +63,6 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           Foreground color
         </p>
         <span>
-          <label
-            class="Input__label"
-            for="input-field"
-          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
@@ -94,10 +86,6 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           Border radius
         </p>
         <span>
-          <label
-            class="Input__label"
-            for="input-field"
-          />
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
@@ -121,10 +109,6 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
         >
           Link decoration
         </p>
-        <label
-          class="Input__label"
-          for="input-field"
-        />
         <input
           class="Input Input--size_small"
           data-lpignore="true"
@@ -178,10 +162,6 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           Background color
         </p>
         <span>
-          <label
-            class="Input__label"
-            for="input-field"
-          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
@@ -205,10 +185,6 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           Foreground color
         </p>
         <span>
-          <label
-            class="Input__label"
-            for="input-field"
-          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
@@ -232,10 +208,6 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           Border radius
         </p>
         <span>
-          <label
-            class="Input__label"
-            for="input-field"
-          />
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
@@ -259,10 +231,6 @@ exports[`ThemeTuner component should render component correctly 1`] = `
         >
           Link decoration
         </p>
-        <label
-          class="Input__label"
-          for="input-field"
-        />
         <input
           class="Input Input--size_small"
           data-lpignore="true"

--- a/src/components/Themeroller/ThemeTuner/__tests__/__snapshots__/ThemeTuner.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/__tests__/__snapshots__/ThemeTuner.spec.tsx.snap
@@ -40,9 +40,14 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           Background color
         </p>
         <span>
+          <label
+            class="Input__label"
+            for="input-field"
+          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id="input-field"
             type="color"
             value="#ffffff"
           />
@@ -62,9 +67,14 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           Foreground color
         </p>
         <span>
+          <label
+            class="Input__label"
+            for="input-field"
+          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id="input-field"
             type="color"
             value="#000000"
           />
@@ -84,9 +94,14 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           Border radius
         </p>
         <span>
+          <label
+            class="Input__label"
+            for="input-field"
+          />
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
+            id="input-field"
             type="number"
             value="3"
           />
@@ -106,9 +121,14 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
         >
           Link decoration
         </p>
+        <label
+          class="Input__label"
+          for="input-field"
+        />
         <input
           class="Input Input--size_small"
           data-lpignore="true"
+          id="input-field"
           type="text"
           value="none"
         />
@@ -158,9 +178,14 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           Background color
         </p>
         <span>
+          <label
+            class="Input__label"
+            for="input-field"
+          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id="input-field"
             type="color"
             value="#ffffff"
           />
@@ -180,9 +205,14 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           Foreground color
         </p>
         <span>
+          <label
+            class="Input__label"
+            for="input-field"
+          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id="input-field"
             type="color"
             value="#000000"
           />
@@ -202,9 +232,14 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           Border radius
         </p>
         <span>
+          <label
+            class="Input__label"
+            for="input-field"
+          />
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
+            id="input-field"
             type="number"
             value="3"
           />
@@ -224,9 +259,14 @@ exports[`ThemeTuner component should render component correctly 1`] = `
         >
           Link decoration
         </p>
+        <label
+          class="Input__label"
+          for="input-field"
+        />
         <input
           class="Input Input--size_small"
           data-lpignore="true"
+          id="input-field"
           type="text"
           value="none"
         />

--- a/src/components/Themeroller/ThemeTuner/__tests__/__snapshots__/ThemeTuner.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/__tests__/__snapshots__/ThemeTuner.spec.tsx.snap
@@ -43,7 +43,7 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
-            id="input-field"
+            id=":r4:"
             type="color"
             value="#ffffff"
           />
@@ -66,7 +66,7 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
-            id="input-field"
+            id=":r5:"
             type="color"
             value="#000000"
           />
@@ -89,7 +89,7 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
-            id="input-field"
+            id=":r6:"
             type="number"
             value="3"
           />
@@ -112,7 +112,7 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
         <input
           class="Input Input--size_small"
           data-lpignore="true"
-          id="input-field"
+          id=":r7:"
           type="text"
           value="none"
         />
@@ -165,7 +165,7 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
-            id="input-field"
+            id=":r0:"
             type="color"
             value="#ffffff"
           />
@@ -188,7 +188,7 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
-            id="input-field"
+            id=":r1:"
             type="color"
             value="#000000"
           />
@@ -211,7 +211,7 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
-            id="input-field"
+            id=":r2:"
             type="number"
             value="3"
           />
@@ -234,7 +234,7 @@ exports[`ThemeTuner component should render component correctly 1`] = `
         <input
           class="Input Input--size_small"
           data-lpignore="true"
-          id="input-field"
+          id=":r3:"
           type="text"
           value="none"
         />

--- a/src/components/Themeroller/__tests__/__snapshots__/Themeroller.spec.tsx.snap
+++ b/src/components/Themeroller/__tests__/__snapshots__/Themeroller.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`Themeroller component should render component correctly 1`] = `
         <input
           class="Input Input--size_small"
           data-lpignore="true"
-          id="input-field"
+          id=":r0:"
           type="text"
           value=""
         />
@@ -62,7 +62,7 @@ exports[`Themeroller component should render component correctly 1`] = `
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
-            id="input-field"
+            id=":r1:"
             type="color"
             value="#ffffff"
           />
@@ -85,7 +85,7 @@ exports[`Themeroller component should render component correctly 1`] = `
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
-            id="input-field"
+            id=":r2:"
             type="color"
             value="#000000"
           />
@@ -108,7 +108,7 @@ exports[`Themeroller component should render component correctly 1`] = `
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
-            id="input-field"
+            id=":r3:"
             type="number"
             value="3"
           />
@@ -131,7 +131,7 @@ exports[`Themeroller component should render component correctly 1`] = `
         <input
           class="Input Input--size_small"
           data-lpignore="true"
-          id="input-field"
+          id=":r4:"
           type="text"
           value="none"
         />

--- a/src/components/Themeroller/__tests__/__snapshots__/Themeroller.spec.tsx.snap
+++ b/src/components/Themeroller/__tests__/__snapshots__/Themeroller.spec.tsx.snap
@@ -10,10 +10,6 @@ exports[`Themeroller component should render component correctly 1`] = `
         <p
           class="Field__label"
         />
-        <label
-          class="Input__label"
-          for="input-field"
-        />
         <input
           class="Input Input--size_small"
           data-lpignore="true"
@@ -63,10 +59,6 @@ exports[`Themeroller component should render component correctly 1`] = `
           Background color
         </p>
         <span>
-          <label
-            class="Input__label"
-            for="input-field"
-          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
@@ -90,10 +82,6 @@ exports[`Themeroller component should render component correctly 1`] = `
           Foreground color
         </p>
         <span>
-          <label
-            class="Input__label"
-            for="input-field"
-          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
@@ -117,10 +105,6 @@ exports[`Themeroller component should render component correctly 1`] = `
           Border radius
         </p>
         <span>
-          <label
-            class="Input__label"
-            for="input-field"
-          />
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
@@ -144,10 +128,6 @@ exports[`Themeroller component should render component correctly 1`] = `
         >
           Link decoration
         </p>
-        <label
-          class="Input__label"
-          for="input-field"
-        />
         <input
           class="Input Input--size_small"
           data-lpignore="true"

--- a/src/components/Themeroller/__tests__/__snapshots__/Themeroller.spec.tsx.snap
+++ b/src/components/Themeroller/__tests__/__snapshots__/Themeroller.spec.tsx.snap
@@ -10,9 +10,14 @@ exports[`Themeroller component should render component correctly 1`] = `
         <p
           class="Field__label"
         />
+        <label
+          class="Input__label"
+          for="input-field"
+        />
         <input
           class="Input Input--size_small"
           data-lpignore="true"
+          id="input-field"
           type="text"
           value=""
         />
@@ -58,9 +63,14 @@ exports[`Themeroller component should render component correctly 1`] = `
           Background color
         </p>
         <span>
+          <label
+            class="Input__label"
+            for="input-field"
+          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id="input-field"
             type="color"
             value="#ffffff"
           />
@@ -80,9 +90,14 @@ exports[`Themeroller component should render component correctly 1`] = `
           Foreground color
         </p>
         <span>
+          <label
+            class="Input__label"
+            for="input-field"
+          />
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id="input-field"
             type="color"
             value="#000000"
           />
@@ -102,9 +117,14 @@ exports[`Themeroller component should render component correctly 1`] = `
           Border radius
         </p>
         <span>
+          <label
+            class="Input__label"
+            for="input-field"
+          />
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
+            id="input-field"
             type="number"
             value="3"
           />
@@ -124,9 +144,14 @@ exports[`Themeroller component should render component correctly 1`] = `
         >
           Link decoration
         </p>
+        <label
+          class="Input__label"
+          for="input-field"
+        />
         <input
           class="Input Input--size_small"
           data-lpignore="true"
+          id="input-field"
           type="text"
           value="none"
         />

--- a/stories/atoms/Input.stories.tsx
+++ b/stories/atoms/Input.stories.tsx
@@ -6,6 +6,12 @@ import { Input } from '@textkernel/oneui';
 export default {
     title: 'Atoms/Input',
     component: Input,
+    argTypes: {
+        context: {
+            control: { type: 'radio' },
+            options: [undefined, 'critical'],
+        },
+    },
 } as Meta<typeof Input>;
 
 type StoryInput = StoryObj<typeof Input>;
@@ -17,6 +23,7 @@ export const _Input: StoryInput = {
         label: 'Label',
         helperText: 'Optional helper text',
         errorMessage: 'Error message',
+        context: undefined,
     },
     render: (args) => <Input {...args} />,
 };

--- a/stories/atoms/Input.stories.tsx
+++ b/stories/atoms/Input.stories.tsx
@@ -14,6 +14,8 @@ export const _Input: StoryInput = {
     name: 'Input',
     args: {
         placeholder: 'While typing, check your console log...',
+        label: 'Label',
+        helperText: 'Optional helper text',
     },
     render: (args) => <Input {...args} />,
 };

--- a/stories/atoms/Input.stories.tsx
+++ b/stories/atoms/Input.stories.tsx
@@ -16,6 +16,7 @@ export const _Input: StoryInput = {
         placeholder: 'While typing, check your console log...',
         label: 'Label',
         helperText: 'Optional helper text',
+        errorMessage: 'Error message',
     },
     render: (args) => <Input {...args} />,
 };

--- a/stories/packages/LocationSelectorUtils.stories.tsx
+++ b/stories/packages/LocationSelectorUtils.stories.tsx
@@ -50,7 +50,6 @@ export const ConvertCoordinatesIntoAddress: Story = {
                         isBlock
                         onChange={(e) => setLet(parseFloat(e.target.value))}
                         placeholder="Enter Lat..."
-                        size="small"
                     />
                     <Input
                         value={lng}
@@ -58,7 +57,6 @@ export const ConvertCoordinatesIntoAddress: Story = {
                         isBlock
                         onChange={(e) => setLng(parseFloat(e.target.value))}
                         placeholder="Enter Lng..."
-                        size="small"
                     />
                     <br />
                     <Button onClick={getAddress}>Get Address</Button>

--- a/stories/packages/LocationSelectorUtils.stories.tsx
+++ b/stories/packages/LocationSelectorUtils.stories.tsx
@@ -50,6 +50,7 @@ export const ConvertCoordinatesIntoAddress: Story = {
                         isBlock
                         onChange={(e) => setLet(parseFloat(e.target.value))}
                         placeholder="Enter Lat..."
+                        size="small"
                     />
                     <Input
                         value={lng}
@@ -57,6 +58,7 @@ export const ConvertCoordinatesIntoAddress: Story = {
                         isBlock
                         onChange={(e) => setLng(parseFloat(e.target.value))}
                         placeholder="Enter Lng..."
+                        size="small"
                     />
                     <br />
                     <Button onClick={getAddress}>Get Address</Button>


### PR DESCRIPTION
[ONEUI-455](https://textkernel.atlassian.net/browse/ONEUI-455)

BREAKING CHANGE: Input component props size, context, and additional states are updated

- size prop options are limited to `small` or `medium`, with `medium` as the default. The options `large` and `normal` have been removed. Replace size="large" or omitting size (previously defaulting to `normal`) with size="medium", or use size="small" as needed.
- context prop only accepts `critical`. Other contexts like `brand` or `success` are removed. For critical contexts, use context="critical" and provide an errorMessage. 
- new `readOnly` prop added to specify if the input field should be non-editable. Replace any custom methods for setting inputs as non-editable with readOnly={true}.
- new `reserveErrorMessageSpace` prop added determine whether space should be reserved for error messages under the input field when validation is expected to avoid "jumping" UI. Default to `false`.

# Checklist
- [x] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [x] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [x] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [x] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [x] Component PropTypes are sufficiently described / documented.
- [x] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
