### PR TITLE
feat(Link): implement new design

### DIFF
--- a/src/__mocks__/svgMock.js
+++ b/src/__mocks__/svgMock.js
@@ -1,4 +1,4 @@
 /* eslint-disable react/display-name, react/destructuring-assignment */
 import React from 'react';
 
-module.exports = (props) => <svg data-testid={props['data-testid'] || 'default-icon'} />;
+module.exports = (props) => <svg {...props} data-testid={props['data-testid'] || 'default-icon'} />;

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -2,7 +2,7 @@
     color: var(--color-link-default);
     text-decoration: underline;
 
-    &:focus {
+    &:focus-visible {
         outline: 2px solid var(--color-border-information-subtle-default, #66AFFF);
     }
 

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -1,33 +1,26 @@
 .Link {
-    color: var(--color-brand-50);
-    text-decoration: var(--link-decoration-normal);
-    transition: color var(--transition-duration);
-
-    &:hover,
-    &:focus {
-        color: var(--color-brand-60);
-        text-decoration: var(--link-decoration-hover);
-    }
+    color: var(--color-link-default);
+    text-decoration: underline;
 
     &:focus {
-        outline: none;
-        border-radius: 5px;
-        border: var(--color-brand-50) solid 2px;
+        outline: 2px solid var(--color-border-information-subtle-default, #66AFFF);
     }
 
-    &:active {
-        color: var(--color-brand-80);
+    &:hover {
+        color: var(--color-link-pressed, #004999);
     }
 
-    &--dontDecorateOnHover:hover {
-        text-decoration: var(--link-decoration-normal);
-    }
-
-    &--isMuted {
-        color: var(--color-neutral-30);
+    &:visited {
+        color: var(--color-link-visited-default, #003166);
 
         &:hover {
-            color: var(--color-neutral-30);
+            color: var(--color-link-visited-pressed, #001833);
         }
+    } 
+
+    &__icon {
+        fill: currentColor;
+        vertical-align: bottom;
+        padding-right: var(--space-25);
     }
 }

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,26 +1,34 @@
 import * as React from 'react';
+import OpenInNew from '@material-design-icons/svg/round/open_in_new.svg';
 import { bem } from '../../utils';
 import styles from './Link.scss';
 
-export interface Props extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
-    /** Link content */
-    children?: React.ReactNode;
-    /** Color context */
-    context?: 'brand' | 'neutral';
-    /** Do not underline text on hover */
-    dontDecorateOnHover?: boolean;
+export interface ExternalLinkProps {
+    /** Indicate external links - an icon will be added */
+    isExternal: true;
+    /** aria label for the external link icon */
+    externalLinkIconLabel: string;
 }
 
-const { block } = bem('Link', styles);
+export interface BaseProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+    /** Link content */
+    children?: React.ReactNode;
+}
+
+export type Props = BaseProps &
+    (ExternalLinkProps | { isExternal?: false; externalLinkIconLabel?: never });
+
+const { block, elem } = bem('Link', styles);
 
 export const Link = React.forwardRef<HTMLAnchorElement, Props>(
-    ({ children, context = 'brand', dontDecorateOnHover = false, ...rest }, ref) => {
+    ({ children, isExternal = false, externalLinkIconLabel, ...rest }, ref) => {
         if (typeof children !== 'number' && !children) {
             return null;
         }
 
         return (
-            <a ref={ref} {...rest} {...block({ context, dontDecorateOnHover, ...rest })}>
+            <a ref={ref} {...rest} {...block({ ...rest })}>
+                {isExternal && <OpenInNew {...elem('icon')} aria-label={externalLinkIconLabel} />}
                 {children}
             </a>
         );

--- a/src/components/Link/__tests__/Link.spec.tsx
+++ b/src/components/Link/__tests__/Link.spec.tsx
@@ -39,4 +39,16 @@ describe('<Link> that renders a link', () => {
         expect(view.container).toMatchSnapshot();
         expect(screen.getByRole('link')).toHaveAttribute('target', '_blank');
     });
+
+    it('should render correctly with external link', () => {
+        const label = 'external link';
+        view.rerender(
+            <Link href={href} isExternal externalLinkIconLabel={label}>
+                external link
+            </Link>
+        );
+
+        expect(view.container).toMatchSnapshot();
+        expect(screen.getByLabelText(label)).toBeInTheDocument();
+    });
 });

--- a/src/components/Link/__tests__/__snapshots__/Link.spec.tsx.snap
+++ b/src/components/Link/__tests__/__snapshots__/Link.spec.tsx.snap
@@ -12,6 +12,22 @@ exports[`<Link> that renders a link should add string html attributes correctly 
 </div>
 `;
 
+exports[`<Link> that renders a link should render correctly with external link 1`] = `
+<div>
+  <a
+    class="Link"
+    href="https://textkernel.com"
+  >
+    <svg
+      aria-label="external link"
+      class="Link__icon"
+      data-testid="default-icon"
+    />
+    external link
+  </a>
+</div>
+`;
+
 exports[`<Link> that renders a link should render default link correctly 1`] = `
 <div>
   <a

--- a/src/components/SelectBadge/__tests__/__snapshots__/SelectBadge.spec.tsx.snap
+++ b/src/components/SelectBadge/__tests__/__snapshots__/SelectBadge.spec.tsx.snap
@@ -19,7 +19,9 @@ exports[`SelectBadge Option button should handle option change correctly 1`] = `
       type="button"
     >
       <svg
+        class="SelectBadge__icon SelectBadge__icon--mandatory"
         data-testid="default-icon"
+        viewBox="0 0 24 24"
       />
     </button>
     <ul
@@ -111,6 +113,8 @@ exports[`SelectBadge Option button should handle option change correctly 1`] = `
     >
       <svg
         data-testid="default-icon"
+        style="width: 20px; height: 20px;"
+        viewBox="0 0 24 24"
       />
     </button>
   </div>
@@ -136,7 +140,9 @@ exports[`SelectBadge Priority button renders correctly with all props provided 1
       type="button"
     >
       <svg
+        class="SelectBadge__icon SelectBadge__icon--mandatory"
         data-testid="default-icon"
+        viewBox="0 0 24 24"
       />
     </button>
     <ul
@@ -184,6 +190,8 @@ exports[`SelectBadge Priority button renders correctly with all props provided 1
     >
       <svg
         data-testid="default-icon"
+        style="width: 20px; height: 20px;"
+        viewBox="0 0 24 24"
       />
     </button>
   </div>
@@ -209,7 +217,9 @@ exports[`SelectBadge Priority button should handle priority change correctly 1`]
       type="button"
     >
       <svg
+        class="SelectBadge__icon SelectBadge__icon--mandatory"
         data-testid="default-icon"
+        viewBox="0 0 24 24"
       />
     </button>
     <ul
@@ -230,7 +240,9 @@ exports[`SelectBadge Priority button should handle priority change correctly 1`]
         role="option"
       >
         <svg
+          class="SelectBadge__icon SelectBadge__icon--mandatory"
           data-testid="default-icon"
+          viewBox="0 0 24 24"
         />
         <span
           class="Text--size_small"
@@ -246,7 +258,9 @@ exports[`SelectBadge Priority button should handle priority change correctly 1`]
         role="option"
       >
         <svg
+          class="SelectBadge__icon SelectBadge__icon--important"
           data-testid="default-icon"
+          viewBox="0 0 24 24"
         />
         <span
           class="Text--size_small"
@@ -262,7 +276,9 @@ exports[`SelectBadge Priority button should handle priority change correctly 1`]
         role="option"
       >
         <svg
+          class="SelectBadge__icon SelectBadge__icon--optional"
           data-testid="default-icon"
+          viewBox="0 0 24 24"
         />
         <span
           class="Text--size_small"
@@ -278,7 +294,9 @@ exports[`SelectBadge Priority button should handle priority change correctly 1`]
         role="option"
       >
         <svg
+          class="SelectBadge__icon SelectBadge__icon--exclude"
           data-testid="default-icon"
+          viewBox="0 0 24 24"
         />
         <span
           class="Text--size_small"
@@ -326,6 +344,8 @@ exports[`SelectBadge Priority button should handle priority change correctly 1`]
     >
       <svg
         data-testid="default-icon"
+        style="width: 20px; height: 20px;"
+        viewBox="0 0 24 24"
       />
     </button>
   </div>

--- a/src/components/Toaster/__tests__/__snapshots__/Toast.spec.tsx.snap
+++ b/src/components/Toaster/__tests__/__snapshots__/Toast.spec.tsx.snap
@@ -76,6 +76,7 @@ exports[`<Toast> should render toast correctly 2`] = `
             type="button"
           >
             <svg
+              class="Toast__closeIcon"
               data-testid="default-icon"
             />
           </button>


### PR DESCRIPTION
Story: [ONEUI-477](https://textkernel.atlassian.net/browse/ONEUI-477)

BREAKING CHANGE: `context` and `doNotDecorateOnHover` props are no longer supported for Link component