### PR TITLE
feat(Input): migrate to new design 

### DIFF
--- a/src/components/FieldWithValidation/__tests__/FieldWithValidation.spec.tsx
+++ b/src/components/FieldWithValidation/__tests__/FieldWithValidation.spec.tsx
@@ -30,7 +30,10 @@ describe('FieldWithValidation', () => {
             );
             expect(container).toMatchSnapshot();
             const input = screen.getByRole('textbox');
-            expect(input).toHaveAttribute('class', 'Input Input--context_critical');
+            expect(input).toHaveAttribute(
+                'class',
+                'Input Input--context_critical Input--size_medium'
+            );
             expect(input).toBeInTheDocument();
             expect(screen.getByText(message)).toBeInTheDocument();
         });
@@ -75,7 +78,10 @@ describe('FieldWithValidation', () => {
 
                 const input = screen.getByRole('textbox');
 
-                expect(input).toHaveAttribute('class', 'Input Input--context_critical');
+                expect(input).toHaveAttribute(
+                    'class',
+                    'Input Input--context_critical Input--size_medium'
+                );
             });
 
             it('should render the message when field is focused', () => {

--- a/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
+++ b/src/components/FieldWithValidation/__tests__/__snapshots__/FieldWithValidation.spec.tsx.snap
@@ -3,8 +3,9 @@
 exports[`FieldWithValidation when rendering message as text with no error message passed should simply render the child as it is 1`] = `
 <div>
   <input
-    class="Input"
+    class="Input Input--size_medium"
     data-lpignore="true"
+    id=":r0:"
     type="text"
     value=""
   />
@@ -14,8 +15,10 @@ exports[`FieldWithValidation when rendering message as text with no error messag
 exports[`FieldWithValidation when using tooltip when error message is defined should remove the message when field is blurred 1`] = `
 <div>
   <input
-    class="Input Input--context_critical"
+    aria-invalid="true"
+    class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
+    id=":r6:"
     type="text"
     value=""
   />
@@ -30,8 +33,10 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
 exports[`FieldWithValidation when using tooltip when error message is defined should render the message when field is focused 1`] = `
 <div>
   <input
-    class="Input Input--context_critical"
+    aria-invalid="true"
+    class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
+    id=":r5:"
     type="text"
     value=""
   />
@@ -46,8 +51,10 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
 exports[`FieldWithValidation when using tooltip when error message is defined should set context to bad on child 1`] = `
 <div>
   <input
-    class="Input Input--context_critical"
+    aria-invalid="true"
+    class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
+    id=":r4:"
     type="text"
     value=""
   />
@@ -62,8 +69,9 @@ exports[`FieldWithValidation when using tooltip when error message is defined sh
 exports[`FieldWithValidation when using tooltip with no error message passed should not render a tooltip with no error message 1`] = `
 <div>
   <input
-    class="Input"
+    class="Input Input--size_medium"
     data-lpignore="true"
+    id=":r3:"
     type="text"
     value=""
   />
@@ -73,8 +81,10 @@ exports[`FieldWithValidation when using tooltip with no error message passed sho
 exports[`FieldWithValidation with error message passed should render the message as text 1`] = `
 <div>
   <input
-    class="Input Input--context_critical"
+    aria-invalid="true"
+    class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
+    id=":r2:"
     type="text"
     value=""
   />
@@ -89,8 +99,10 @@ exports[`FieldWithValidation with error message passed should render the message
 exports[`FieldWithValidation with error message passed should set context to bad on child 1`] = `
 <div>
   <input
-    class="Input Input--context_critical"
+    aria-invalid="true"
+    class="Input Input--context_critical Input--size_medium"
     data-lpignore="true"
+    id=":r1:"
     type="text"
     value=""
   />

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -1,24 +1,17 @@
-@import '../../themes/oneui/placeholders/input';
-@import '../../themes/oneui/constants/colors';
-
 .Input {
-    @extend %input;
-
-    border-color: var(--color-neutral-20);
-
-    &--context {
-        @each $context in ($contexts) {
-            &_#{ $context } {
-                border-color: var(--color-#{$context}-50);
-                &:focus {
-                    border-color: var(--color-#{$context}-50);
-                }
-            }
-        }
+    border: {
+        color: var(--color-border-input);
+        radius: var(--space-100);
+        style: solid;
+        width: var(--line-normal);
     }
+    background-color: var(--color-background-input-default);
+    box-sizing: border-box;
+    composes: OneUI-label-text from global;
 
     &::placeholder {
-        color: var(--color-neutral-30);
+        color: var(--color-text-subtlest);
+        line-height: var(--line-height-small);
         opacity: 1;
     }
 
@@ -26,22 +19,128 @@
         width: 100%;
     }
 
+    &:hover {
+        background-color: var(--color-background-input-hover);
+        border: 1px solid var(--color-border-input);
+    }
+
+    &:focus {
+        background-color: inherit;
+        border: 2px solid var(--color-border-selected);
+        outline: none;
+    }
+
     &[disabled] {
-        background-color: var(--color-background);
+        background-color: var(--color-background-input-default);
+        color: var(--color-text-disabled);
+        border: 1px solid var(--color-border-disabled);
+        cursor: not-allowed;
+
+        &::placeholder {
+            color: var(--color-text-disabled);
+        }
+    }
+
+    &[readOnly] {
+        background-color: var(--color-background-input-read-only);
+        border: none;
     }
 
     &--size {
         &_small {
-            min-height: 26px;
-            height: 26px;
-            font-size: var(--font-size-small);
-            line-height: var(--line-height-small);
-            padding: var(--space-50);
+            padding: var(--space-75) var(--space-100);
+            height: 32px;
+
+            &:focus:not(.Input--context_critical):not([readOnly]) {
+                padding: var(--space-75) calc(var(--space-100) - 1px);
+            }
+
+            &.Input--context_critical {
+                padding: var(--space-75) calc(var(--space-100) - 1px);
+            }
         }
-        &_large {
-            font-size: var(--font-size-large);
-            line-height: var(--line-height-large);
-            padding: var(--space-100);
+
+        &_medium {
+            padding: calc(var(--space-25) * 5) var(--space-150);
+            height: 40px;
+
+            &:focus:not(.Input--context_critical):not([readOnly]) {
+                padding: calc(var(--space-25) * 5) calc(var(--space-150) - 1px);
+            }
+
+            &.Input--context_critical {
+                padding: calc(var(--space-25) * 5) calc(var(--space-150) - 1px);
+            }
+        }
+    }
+
+    &--context_critical,
+    &:invalid {
+        border: 2px solid var(--color-border-critical-bold-default);
+        outline: none;
+
+        &:focus,
+        &:hover {
+            border: 2px solid var(--color-border-critical-bold-default);
+            background-color: inherit;
+            outline: none;
+        }
+    }
+
+    &__label {
+        margin-bottom: var(--space-50);
+        padding: 0 var(--space-50);
+        composes: OneUI-caption-text-bold from global;
+        display: block;
+    }
+
+    &__errorMessageWrapper {
+        margin-top: var(--space-50);
+        padding: 0 var(--space-50);
+        display: flex;
+        gap: var(--space-25);
+        align-items: center;
+
+        &--reserveErrorMessageSpace {
+            min-height: 16px;
+            box-sizing: content-box;
+        }
+    }
+
+    &__errorMessage {
+        margin: 0;
+        composes: OneUI-caption-text from global;
+        color: var(--color-text-critical-default);
+
+        &--reserveErrorMessageSpace {
+            display: none;
+        }
+
+        &--context_critical,
+        &:invalid {
+            display: block;
+        }
+    }
+
+    &__helperText {
+        margin: var(--space-50) 0 0;
+        padding: 0 var(--space-50);
+        composes: OneUI-caption-text from global;
+        color: var(--color-text-subtlest);
+    }
+
+    &__icon {
+        width: 16px;
+        height: 16px;
+        fill: var(--color-icon-critical-default);
+
+        &--reserveErrorMessageSpace {
+            display: none;
+        }
+
+        &--context_critical,
+        &:invalid {
+            display: block;
         }
     }
 }

--- a/src/components/Input/__tests__/Input.spec.tsx
+++ b/src/components/Input/__tests__/Input.spec.tsx
@@ -2,14 +2,23 @@ import React from 'react';
 import { render, RenderResult, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { Input } from '../Input';
+import { Input, Props } from '../Input';
+
+const defaultProps: Props = {
+    label: 'Input Label',
+    type: 'text',
+    helperText: 'This is a helper text',
+    context: undefined,
+};
+
+const renderComponent = (props = {}) => render(<Input {...defaultProps} {...props} />);
 
 describe('<Input> that renders an input field', () => {
     let view: RenderResult;
 
     it('should render default input correctly', () => {
         const onChange = jest.fn();
-        view = render(<Input value="Some value" onChange={onChange} />);
+        view = renderComponent({ value: 'Some value', onChange });
         const textbox = screen.getByRole('textbox');
 
         expect(view.container).toMatchSnapshot();
@@ -18,21 +27,69 @@ describe('<Input> that renders an input field', () => {
     });
 
     it('should add classes when props are changed', () => {
-        view = render(<Input context="critical" size="large" isBlock disabled />);
+        view = renderComponent({
+            context: 'critical',
+            isBlock: true,
+            disabled: true,
+        });
         const textbox = screen.getByRole('textbox');
 
         expect(view.container).toMatchSnapshot();
         expect(textbox).toBeInTheDocument();
         expect(textbox).toHaveClass(
-            'Input Input--context_critical Input--size_large Input--isBlock'
+            'Input Input--context_critical Input--size_medium Input--isBlock'
         );
         expect(textbox).toHaveAttribute('disabled');
+    });
+
+    it('should render input with label', () => {
+        const label = 'Input Label';
+        view = renderComponent({ label });
+        const labelText = screen.getByText(label);
+
+        expect(labelText).toBeInTheDocument();
+        expect(screen.getByLabelText(label)).toBeInTheDocument();
+    });
+
+    it('should show helper text when provided', () => {
+        const helperText = 'This is helper text';
+        view = renderComponent({
+            helperText,
+        });
+        const helperTextElement = screen.getByText(helperText);
+
+        expect(helperTextElement).toBeInTheDocument();
+        expect(helperTextElement).toHaveClass('Input__helperText');
+    });
+
+    it('should display errorMessage instead of helper text when context is critical', () => {
+        const helperText = 'This is helper text';
+        const errorMessage = 'Value is invalid';
+        view = renderComponent({
+            context: 'critical',
+            errorMessage,
+            helperText,
+        });
+
+        const errorMessageElement = screen.getByText(errorMessage);
+        expect(errorMessageElement).toBeInTheDocument();
+        expect(errorMessageElement).toHaveClass('Input__errorMessage');
+
+        expect(screen.queryByText(helperText)).not.toBeInTheDocument();
+    });
+
+    it('should handle readOnly state correctly', () => {
+        view = renderComponent({ readOnly: true });
+
+        const textbox = screen.getByRole('textbox');
+
+        expect(textbox).toHaveAttribute('readOnly');
     });
 
     it('should call change callback correctly', async () => {
         const user = userEvent.setup();
         const onChange = jest.fn();
-        view = render(<Input onChange={onChange} />);
+        view = renderComponent({ onChange });
 
         await user.type(screen.getByRole('textbox'), 'test');
 
@@ -40,7 +97,7 @@ describe('<Input> that renders an input field', () => {
     });
 
     it('should add string html attributes correctly', () => {
-        view = render(<Input data-test="something" />);
+        view = renderComponent({ 'data-test': 'something' });
 
         expect(screen.getByRole('textbox')).toHaveAttribute('data-test', 'something');
     });

--- a/src/components/Input/__tests__/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__tests__/__snapshots__/Input.spec.tsx.snap
@@ -2,23 +2,48 @@
 
 exports[`<Input> that renders an input field should add classes when props are changed 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for=":r1:"
+  >
+    Input Label
+  </label>
   <input
-    class="Input Input--context_critical Input--size_large Input--isBlock"
+    aria-invalid="true"
+    class="Input Input--context_critical Input--size_medium Input--isBlock"
     data-lpignore="true"
     disabled=""
+    id=":r1:"
     type="text"
     value=""
   />
+  <p
+    class="Input__helperText"
+  >
+    This is a helper text
+  </p>
 </div>
 `;
 
 exports[`<Input> that renders an input field should render default input correctly 1`] = `
 <div>
+  <label
+    class="Input__label"
+    for=":r0:"
+  >
+    Input Label
+  </label>
   <input
-    class="Input"
+    class="Input Input--size_medium"
     data-lpignore="true"
+    id=":r0:"
     type="text"
     value="Some value"
   />
+  <p
+    class="Input__helperText"
+  >
+    This is a helper text
+  </p>
 </div>
 `;

--- a/src/components/Themeroller/ThemeTuner/ItemValue/ColorValue/__tests__/__snapshots__/ColorValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/ColorValue/__tests__/__snapshots__/ColorValue.spec.tsx.snap
@@ -6,6 +6,7 @@ exports[`ColorValue component should render component correctly 1`] = `
     <input
       class="Input Input--size_small ColorValue__input"
       data-lpignore="true"
+      id=":r0:"
       role="colorselector"
       type="color"
       value="#fffff"

--- a/src/components/Themeroller/ThemeTuner/ItemValue/NumberValue/__tests__/__snapshots__/NumberValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/NumberValue/__tests__/__snapshots__/NumberValue.spec.tsx.snap
@@ -5,6 +5,7 @@ exports[`NumberValue component should render component correctly 1`] = `
   <input
     class="Input Input--size_small"
     data-lpignore="true"
+    id=":r0:"
     role="numberselector"
     type="number"
     value="100"

--- a/src/components/Themeroller/ThemeTuner/ItemValue/StringValue/__tests__/__snapshots__/StringValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/StringValue/__tests__/__snapshots__/StringValue.spec.tsx.snap
@@ -5,6 +5,7 @@ exports[`StringValue component should render component correctly 1`] = `
   <input
     class="Input Input--size_small"
     data-lpignore="true"
+    id=":r0:"
     type="text"
     value="flex"
   />

--- a/src/components/Themeroller/ThemeTuner/ItemValue/UnitValue/__tests__/__snapshots__/UnitValue.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/ItemValue/UnitValue/__tests__/__snapshots__/UnitValue.spec.tsx.snap
@@ -6,6 +6,7 @@ exports[`UnitValue component should render component correctly 1`] = `
     <input
       class="Input Input--size_small UnitValue__input"
       data-lpignore="true"
+      id=":r0:"
       type="number"
       value="12"
     />

--- a/src/components/Themeroller/ThemeTuner/__tests__/__snapshots__/ThemeTuner.spec.tsx.snap
+++ b/src/components/Themeroller/ThemeTuner/__tests__/__snapshots__/ThemeTuner.spec.tsx.snap
@@ -43,6 +43,7 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id=":r4:"
             type="color"
             value="#ffffff"
           />
@@ -65,6 +66,7 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id=":r5:"
             type="color"
             value="#000000"
           />
@@ -87,6 +89,7 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
+            id=":r6:"
             type="number"
             value="3"
           />
@@ -109,6 +112,7 @@ exports[`ThemeTuner component should invoke onChange callback when first input w
         <input
           class="Input Input--size_small"
           data-lpignore="true"
+          id=":r7:"
           type="text"
           value="none"
         />
@@ -161,6 +165,7 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id=":r0:"
             type="color"
             value="#ffffff"
           />
@@ -183,6 +188,7 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id=":r1:"
             type="color"
             value="#000000"
           />
@@ -205,6 +211,7 @@ exports[`ThemeTuner component should render component correctly 1`] = `
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
+            id=":r2:"
             type="number"
             value="3"
           />
@@ -227,6 +234,7 @@ exports[`ThemeTuner component should render component correctly 1`] = `
         <input
           class="Input Input--size_small"
           data-lpignore="true"
+          id=":r3:"
           type="text"
           value="none"
         />

--- a/src/components/Themeroller/__tests__/__snapshots__/Themeroller.spec.tsx.snap
+++ b/src/components/Themeroller/__tests__/__snapshots__/Themeroller.spec.tsx.snap
@@ -13,6 +13,7 @@ exports[`Themeroller component should render component correctly 1`] = `
         <input
           class="Input Input--size_small"
           data-lpignore="true"
+          id=":r0:"
           type="text"
           value=""
         />
@@ -61,6 +62,7 @@ exports[`Themeroller component should render component correctly 1`] = `
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id=":r1:"
             type="color"
             value="#ffffff"
           />
@@ -83,6 +85,7 @@ exports[`Themeroller component should render component correctly 1`] = `
           <input
             class="Input Input--size_small ColorValue__input"
             data-lpignore="true"
+            id=":r2:"
             type="color"
             value="#000000"
           />
@@ -105,6 +108,7 @@ exports[`Themeroller component should render component correctly 1`] = `
           <input
             class="Input Input--size_small UnitValue__input"
             data-lpignore="true"
+            id=":r3:"
             type="number"
             value="3"
           />
@@ -127,6 +131,7 @@ exports[`Themeroller component should render component correctly 1`] = `
         <input
           class="Input Input--size_small"
           data-lpignore="true"
+          id=":r4:"
           type="text"
           value="none"
         />

--- a/stories/atoms/Input.stories.tsx
+++ b/stories/atoms/Input.stories.tsx
@@ -6,6 +6,12 @@ import { Input } from '@textkernel/oneui';
 export default {
     title: 'Atoms/Input',
     component: Input,
+    argTypes: {
+        context: {
+            control: { type: 'radio' },
+            options: [undefined, 'critical'],
+        },
+    },
 } as Meta<typeof Input>;
 
 type StoryInput = StoryObj<typeof Input>;
@@ -14,6 +20,10 @@ export const _Input: StoryInput = {
     name: 'Input',
     args: {
         placeholder: 'While typing, check your console log...',
+        label: 'Label',
+        helperText: 'Optional helper text',
+        errorMessage: 'Error message',
+        context: undefined,
     },
     render: (args) => <Input {...args} />,
 };


### PR DESCRIPTION
New PR for the https://github.com/textkernel/oneui/pull/1248 to add breaking changes in the commit message

# Checklist
- [ ] The implementation has been manually tested and complies with Textkernel [browser support guidelines](https://textkernel.com/browser-support/)
- [ ] The implementation complies with [accessibility](CONTIRBUTING.md#accessibility) standards.
- [ ] The component has a [displayName](CONTRIBUTING.md#display-names) defined.
- [ ] The component comes with a detailed [PropTypes](CONTRIBUTING.md#component-props) (and defaultProps) definition.
- [ ] Component PropTypes are sufficiently described / documented.
- [ ] There is [a story](CONTRIBUTING.md#component-showcases) in Storybook.
